### PR TITLE
Modernize Android build: migrate from 2018 support libraries to AndroidX

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,5 +38,6 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,37 +1,42 @@
 apply plugin: 'com.android.application'
-
 apply plugin: 'kotlin-android'
 
-apply plugin: 'kotlin-android-extensions'
-
 android {
-    compileSdkVersion 28
+    namespace 'gabbard.org.pandemicgenerator'
+    compileSdk 34
     defaultConfig {
         applicationId "gabbard.org.pandemicgenerator"
-        minSdkVersion 27
-        targetSdkVersion 28
+        minSdk 21
+        targetSdk 34
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-    productFlavors {
+    buildFeatures {
+        viewBinding true
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+    kotlinOptions {
+        jvmTarget = '11'
     }
 }
 
 dependencies {
     implementation project(':pandemic-generator-core')
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0-alpha3'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
-    api 'com.google.guava:guava:25.1-android'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/app/src/androidTest/java/gabbard/org/pandemicgenerator/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/gabbard/org/pandemicgenerator/ExampleInstrumentedTest.kt
@@ -1,22 +1,16 @@
 package gabbard.org.pandemicgenerator
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 
-/**
- * Instrumented test, which will execute on an Android device.
- *
- * See [testing documentation](http://d.android.com/tools/testing).
- */
 @RunWith(AndroidJUnit4::class)
 class ExampleInstrumentedTest {
     @Test
     fun useAppContext() {
-        // Context of the app under test.
-        val appContext = InstrumentationRegistry.getTargetContext()
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         assertEquals("gabbard.org.pandemicgenerator", appContext.packageName)
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="gabbard.org.pandemicgenerator">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
@@ -2,15 +2,16 @@ package gabbard.org.pandemicgenerator
 
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.view.View
-import kotlinx.android.synthetic.main.activity_draw_player_cards.*
+import androidx.appcompat.app.AppCompatActivity
+import gabbard.org.pandemicgenerator.databinding.ActivityDrawPlayerCardsBinding
 import org.gabbard.pandemicgenerator.TrackableState
 import org.gabbard.pandemicgenerator.Transition
 import org.gabbard.pandemicgenerator.messageForTransitionResult
 import java.util.*
 
 class DrawPlayerCards : AppCompatActivity() {
+    private lateinit var binding: ActivityDrawPlayerCardsBinding
     private var gameState: TrackableState? = null
     private var rng: Random? = null
 
@@ -21,20 +22,20 @@ class DrawPlayerCards : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_draw_player_cards)
+        binding = ActivityDrawPlayerCardsBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         gameState = intent.getSerializableExtra(DrawPlayerCards.GAME_STATE) as TrackableState
         rng = intent.getSerializableExtra(DrawPlayerCards.RANDOM_SOURCE) as Random
         val drawResult = gameState!!.executeTransition(Transition.DRAW_PLAYER_CARDS, rng!!)
 
         gameState = drawResult.newGameState
-        drawResultMessage.text = messageForTransitionResult(drawResult)
+        binding.drawResultMessage.text = messageForTransitionResult(drawResult)
     }
 
     fun onProceedToInfectionPhase(view: View) {
         val infetionIntent = Intent(this, InfectionActivity::class.java)
         infetionIntent.putExtra(InfectionActivity.GAME_STATE, gameState!!)
         infetionIntent.putExtra(InfectionActivity.RANDOM_SOURCE, rng!!)
-
         startActivity(infetionIntent)
     }
 }

--- a/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
@@ -34,7 +34,7 @@ class DrawPlayerCards : AppCompatActivity() {
         binding.drawResultMessage.text = messageForTransitionResult(drawResult)
     }
 
-    fun onProceedToInfectionPhase(view: View) {
+    fun onProceedToInfectionPhase(@Suppress("UNUSED_PARAMETER") view: View) {
         val infetionIntent = Intent(this, InfectionActivity::class.java)
         infetionIntent.putExtra(InfectionActivity.GAME_STATE, gameState!!)
         infetionIntent.putExtra(InfectionActivity.RANDOM_SOURCE, rng!!)

--- a/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
@@ -24,7 +24,9 @@ class DrawPlayerCards : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityDrawPlayerCardsBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        @Suppress("DEPRECATION")
         gameState = intent.getSerializableExtra(DrawPlayerCards.GAME_STATE) as TrackableState
+        @Suppress("DEPRECATION")
         rng = intent.getSerializableExtra(DrawPlayerCards.RANDOM_SOURCE) as Random
         val drawResult = gameState!!.executeTransition(Transition.DRAW_PLAYER_CARDS, rng!!)
 

--- a/app/src/main/java/gabbard/org/pandemicgenerator/EnterRandomSeed.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/EnterRandomSeed.kt
@@ -16,7 +16,7 @@ class EnterRandomSeed : AppCompatActivity() {
         setContentView(binding.root)
     }
 
-    fun startGame(view: View) {
+    fun startGame(@Suppress("UNUSED_PARAMETER") view: View) {
         val rng = Random(binding.startGame.text.toString().toLong())
 
         val startGameIntent = Intent(this, InitialSetup::class.java)

--- a/app/src/main/java/gabbard/org/pandemicgenerator/EnterRandomSeed.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/EnterRandomSeed.kt
@@ -2,20 +2,22 @@ package gabbard.org.pandemicgenerator
 
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.view.View
-import kotlinx.android.synthetic.main.activity_enter_random_seed.*
+import androidx.appcompat.app.AppCompatActivity
+import gabbard.org.pandemicgenerator.databinding.ActivityEnterRandomSeedBinding
 import java.util.*
 
 class EnterRandomSeed : AppCompatActivity() {
+    private lateinit var binding: ActivityEnterRandomSeedBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_enter_random_seed)
+        binding = ActivityEnterRandomSeedBinding.inflate(layoutInflater)
+        setContentView(binding.root)
     }
 
     fun startGame(view: View) {
-        val rng = Random(startGame.text.toString().toLong())
+        val rng = Random(binding.startGame.text.toString().toLong())
 
         val startGameIntent = Intent(this, InitialSetup::class.java)
         startGameIntent.putExtra(InitialSetup.RANDOM_SOURCE, rng)

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
@@ -2,15 +2,16 @@ package gabbard.org.pandemicgenerator
 
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.view.View
-import kotlinx.android.synthetic.main.activity_infection.*
+import androidx.appcompat.app.AppCompatActivity
+import gabbard.org.pandemicgenerator.databinding.ActivityInfectionBinding
 import org.gabbard.pandemicgenerator.TrackableState
 import org.gabbard.pandemicgenerator.Transition
 import org.gabbard.pandemicgenerator.messageForTransitionResult
 import java.util.*
 
 class InfectionActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityInfectionBinding
     var gameState: TrackableState? = null
     var rng: Random? = null
 
@@ -21,12 +22,13 @@ class InfectionActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_infection)
+        binding = ActivityInfectionBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         gameState = intent.getSerializableExtra(InfectionActivity.GAME_STATE) as TrackableState
         rng = intent.getSerializableExtra(InfectionActivity.RANDOM_SOURCE) as Random
 
         val infectionResult = gameState!!.executeTransition(Transition.INFECT, rng!!)
-        infectionResultMessage.text = messageForTransitionResult(infectionResult)
+        binding.infectionResultMessage.text = messageForTransitionResult(infectionResult)
         gameState = infectionResult.newGameState
     }
 
@@ -34,7 +36,6 @@ class InfectionActivity : AppCompatActivity() {
         val turnTimerIntent = Intent(this, TurnTimer::class.java)
         turnTimerIntent.putExtra(TurnTimer.GAME_STATE, gameState!!)
         turnTimerIntent.putExtra(TurnTimer.RANDOM_SOURCE, rng!!)
-
         startActivity(turnTimerIntent)
     }
 }

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
@@ -24,7 +24,9 @@ class InfectionActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityInfectionBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        @Suppress("DEPRECATION")
         gameState = intent.getSerializableExtra(InfectionActivity.GAME_STATE) as TrackableState
+        @Suppress("DEPRECATION")
         rng = intent.getSerializableExtra(InfectionActivity.RANDOM_SOURCE) as Random
 
         val infectionResult = gameState!!.executeTransition(Transition.INFECT, rng!!)

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
@@ -34,7 +34,7 @@ class InfectionActivity : AppCompatActivity() {
         gameState = infectionResult.newGameState
     }
 
-    fun onNextTurn(view: View) {
+    fun onNextTurn(@Suppress("UNUSED_PARAMETER") view: View) {
         val turnTimerIntent = Intent(this, TurnTimer::class.java)
         turnTimerIntent.putExtra(TurnTimer.GAME_STATE, gameState!!)
         turnTimerIntent.putExtra(TurnTimer.RANDOM_SOURCE, rng!!)

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InitialSetup.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InitialSetup.kt
@@ -23,6 +23,7 @@ class InitialSetup : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityInitialSetupBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        @Suppress("DEPRECATION")
         rng = intent.getSerializableExtra(RANDOM_SOURCE) as Random
 
         val fullGameState = NATIONAL_CHAMPIONSHIP_RULES.setupGame(rng!!)

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InitialSetup.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InitialSetup.kt
@@ -2,15 +2,16 @@ package gabbard.org.pandemicgenerator
 
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.view.View
-import kotlinx.android.synthetic.main.activity_initial_setup.*
+import androidx.appcompat.app.AppCompatActivity
+import gabbard.org.pandemicgenerator.databinding.ActivityInitialSetupBinding
 import org.gabbard.pandemicgenerator.NATIONAL_CHAMPIONSHIP_RULES
 import org.gabbard.pandemicgenerator.TrackableState
 import java.util.*
 
 
 class InitialSetup : AppCompatActivity() {
+    private lateinit var binding: ActivityInitialSetupBinding
     private var gameState: TrackableState? = null
     private var rng: Random? = null
 
@@ -20,7 +21,8 @@ class InitialSetup : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_initial_setup)
+        binding = ActivityInitialSetupBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         rng = intent.getSerializableExtra(RANDOM_SOURCE) as Random
 
         val fullGameState = NATIONAL_CHAMPIONSHIP_RULES.setupGame(rng!!)
@@ -31,11 +33,9 @@ class InitialSetup : AppCompatActivity() {
             throw RuntimeException("Only two players currently supported. Issue #10")
         }
         val hands = fullGameState.untrackableState.hands
-        player1.text = players[0].role.name + ": " +
-                hands[players[0]]
-        player2.text = players[1].role.name + ": " +
-                hands[players[1]]
-        board.text = fullGameState.untrackableState.board.cityStates.toString()
+        binding.player1.text = players[0].role.name + ": " + hands[players[0]]
+        binding.player2.text = players[1].role.name + ": " + hands[players[1]]
+        binding.board.text = fullGameState.untrackableState.board.cityStates.toString()
     }
 
     fun readyToPlay(view: View) {

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InitialSetup.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InitialSetup.kt
@@ -39,7 +39,7 @@ class InitialSetup : AppCompatActivity() {
         binding.board.text = fullGameState.untrackableState.board.cityStates.toString()
     }
 
-    fun readyToPlay(view: View) {
+    fun readyToPlay(@Suppress("UNUSED_PARAMETER") view: View) {
         val turnTimerIntent = Intent(this, TurnTimer::class.java)
         turnTimerIntent.putExtra(TurnTimer.GAME_STATE, gameState)
         turnTimerIntent.putExtra(TurnTimer.RANDOM_SOURCE, rng)

--- a/app/src/main/java/gabbard/org/pandemicgenerator/MainActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/MainActivity.kt
@@ -2,8 +2,8 @@ package gabbard.org.pandemicgenerator
 
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
 import android.view.View
+import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
 

--- a/app/src/main/java/gabbard/org/pandemicgenerator/MainActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/MainActivity.kt
@@ -12,7 +12,7 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
     }
 
-    fun startGame(view: View) {
+    fun startGame(@Suppress("UNUSED_PARAMETER") view: View) {
         val startGameIntent = Intent(this, EnterRandomSeed::class.java)
         startActivity(startGameIntent)
     }

--- a/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
@@ -27,7 +27,9 @@ class TurnTimer : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityTurnTimerBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        @Suppress("DEPRECATION")
         gameState = intent.getSerializableExtra(GAME_STATE) as TrackableState
+        @Suppress("DEPRECATION")
         rng = intent.getSerializableExtra(RANDOM_SOURCE) as Random
         binding.timeRemaining.isCountDown = true
         binding.timeRemaining.start()

--- a/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
@@ -54,7 +54,7 @@ class TurnTimer : AppCompatActivity() {
         }
     }
 
-    fun onDrawPlayerCards(view: View) {
+    fun onDrawPlayerCards(@Suppress("UNUSED_PARAMETER") view: View) {
         val drawPlayerCardsIntent = Intent(this, DrawPlayerCards::class.java)
         drawPlayerCardsIntent.putExtra(DrawPlayerCards.GAME_STATE, gameState!!)
         drawPlayerCardsIntent.putExtra(DrawPlayerCards.RANDOM_SOURCE, rng!!)

--- a/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
@@ -5,15 +5,16 @@ import android.graphics.Color
 import android.media.RingtoneManager
 import android.os.Bundle
 import android.os.SystemClock
-import android.support.v7.app.AppCompatActivity
 import android.view.View
 import android.widget.Chronometer
-import kotlinx.android.synthetic.main.activity_turn_timer.*
+import androidx.appcompat.app.AppCompatActivity
+import gabbard.org.pandemicgenerator.databinding.ActivityTurnTimerBinding
 import org.gabbard.pandemicgenerator.TrackableState
 import java.util.*
 
 
 class TurnTimer : AppCompatActivity() {
+    private lateinit var binding: ActivityTurnTimerBinding
     private var gameState: TrackableState? = null
     private var rng: Random? = null
 
@@ -24,21 +25,22 @@ class TurnTimer : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_turn_timer)
+        binding = ActivityTurnTimerBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         gameState = intent.getSerializableExtra(GAME_STATE) as TrackableState
         rng = intent.getSerializableExtra(RANDOM_SOURCE) as Random
-        timeRemaining.isCountDown = true
-        timeRemaining.start()
+        binding.timeRemaining.isCountDown = true
+        binding.timeRemaining.start()
         val targetTime = SystemClock.elapsedRealtime() + 75 * 1000
-        timeRemaining.base = targetTime
-        timeRemaining.onChronometerTickListener = Chronometer.OnChronometerTickListener {
+        binding.timeRemaining.base = targetTime
+        binding.timeRemaining.onChronometerTickListener = Chronometer.OnChronometerTickListener {
             val timeTilTarget = targetTime - SystemClock.elapsedRealtime()
             if (timeTilTarget <= 0) {
                 try {
                     val notification = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
                     val r = RingtoneManager.getRingtone(applicationContext, notification)
                     r.play()
-                    timeRemaining.stop()
+                    binding.timeRemaining.stop()
                 } catch (e: Exception) {
                     e.printStackTrace()
                 }
@@ -54,7 +56,6 @@ class TurnTimer : AppCompatActivity() {
         val drawPlayerCardsIntent = Intent(this, DrawPlayerCards::class.java)
         drawPlayerCardsIntent.putExtra(DrawPlayerCards.GAME_STATE, gameState!!)
         drawPlayerCardsIntent.putExtra(DrawPlayerCards.RANDOM_SOURCE, rng!!)
-
         startActivity(drawPlayerCardsIntent)
     }
 }

--- a/app/src/main/res/layout/activity_draw_player_cards.xml
+++ b/app/src/main/res/layout/activity_draw_player_cards.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -23,4 +23,4 @@
         android:text="Proceed to Infection Phase"
         app:layout_constraintTop_toBottomOf="@+id/drawResultMessage"
         tools:layout_editor_absoluteX="97dp" />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_enter_random_seed.xml
+++ b/app/src/main/res/layout/activity_enter_random_seed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -35,4 +35,4 @@
         tools:layout_editor_absoluteX="153dp"
         tools:layout_editor_absoluteY="232dp" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_infection.xml
+++ b/app/src/main/res/layout/activity_infection.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -23,4 +23,4 @@
         android:text="Next Turn"
         app:layout_constraintTop_toBottomOf="@+id/infectionResultMessage"
         tools:layout_editor_absoluteX="148dp" />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_initial_setup.xml
+++ b/app/src/main/res/layout/activity_initial_setup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -41,4 +41,4 @@
         android:text="Ready to Play"
         app:layout_constraintTop_toBottomOf="@+id/board"
         tools:layout_editor_absoluteX="74dp" />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -14,4 +14,4 @@
         tools:layout_editor_absoluteX="148dp"
         tools:layout_editor_absoluteY="309dp" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_turn_timer.xml
+++ b/app/src/main/res/layout/activity_turn_timer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -23,4 +23,4 @@
         android:text="Draw Player Cards"
         app:layout_constraintTop_toBottomOf="@+id/timeRemaining"
         tools:layout_editor_absoluteX="109dp" />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -1,33 +1,19 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
-    ext.kotlin_version = '1.2.30'
+    ext.kotlin_version = '1.9.25'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:8.3.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
-subprojects { subProject ->
-    afterEvaluate {
-        if (subProject.plugins.hasPlugin("kotlin") && subProject.plugins.hasPlugin("java-library")) {
-            subProject.kotlin.copyClassesToJavaOutput = true
-            subProject.jar.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-        }
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
+android.useAndroidX=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/pandemic-generator-core/build.gradle
+++ b/pandemic-generator-core/build.gradle
@@ -3,16 +3,11 @@ apply plugin: 'kotlin'
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-
-    api 'com.google.guava:guava:26.0-android'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    api 'com.google.guava:guava:33.0.0-android'
 }
 
-repositories {
-    mavenCentral()
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
-
-sourceCompatibility = "1.7"
-targetCompatibility = "1.7"
-
-

--- a/pandemic-generator-core/build.gradle
+++ b/pandemic-generator-core/build.gradle
@@ -11,3 +11,9 @@ java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        jvmTarget = '11'
+    }
+}

--- a/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/ComputeDeckBoundaries.kt
+++ b/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/ComputeDeckBoundaries.kt
@@ -7,7 +7,7 @@ import java.util.*
 const val NUM_CARDS_FOR_PLAYER_HANDS = 2 * 4
 
 
-fun main(args: Array<String>) {
+fun main(@Suppress("UNUSED_PARAMETER") args: Array<String>) {
     val numSamples = 10000
     val rng = Random(0)
 

--- a/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/GameState.kt
+++ b/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/GameState.kt
@@ -120,7 +120,7 @@ data class TrackableState(val curPlayer: Int,
     private data class EpidemicExecutionResult(val newCity: City, val newGameState: TrackableState)
 
     private fun executeEpidemic(rng: Random): EpidemicExecutionResult {
-        val newInfectionRate = InfectionRate.values()[infectionRate.ordinal + 1]
+        val newInfectionRate = InfectionRate.entries[infectionRate.ordinal + 1]
         val (infectionCardOffTheBottom, infectionDeckAfterNewCity) = infectionDeck.drawOneFromTheBottom()
         val newInfectionDeck = Deck(infectionDiscardPile.toList().plus(infectionCardOffTheBottom))
                 .shuffled(rng).placeOnTopOf(infectionDeckAfterNewCity)

--- a/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/PandemicGeneratorCli.kt
+++ b/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/PandemicGeneratorCli.kt
@@ -28,7 +28,7 @@ fun messageForTransitionResult(result: TrackableState.TransitionResult): String 
         }
     }
 }
-fun main(args: Array<String>) {
+fun main(@Suppress("UNUSED_PARAMETER") args: Array<String>) {
     print("Enter random seed: ")
     val rng = Random(readLine()!!.toLong())
     val initialState = NATIONAL_CHAMPIONSHIP_RULES.setupGame(rng)


### PR DESCRIPTION
- Gradle wrapper: 4.4 → 8.7
- Android Gradle Plugin: 3.1.3 → 8.3.2
- Kotlin: 1.2.30 → 1.9.25
- compileSdk/targetSdk: 28 → 34, minSdk: 27 → 21
- Replace deprecated jcenter() with mavenCentral()
- Migrate all android.support.* deps to AndroidX equivalents
- Replace deprecated kotlin-android-extensions with View Binding in all activities
- Update ConstraintLayout references in all layouts to androidx.constraintlayout
- Upgrade Guava: 26.0-android → 33.0.0-android
- Set Java source/target compatibility to VERSION_11
- Move namespace from AndroidManifest package attribute to build.gradle

https://claude.ai/code/session_01X9AsSLcveZ9GMFh59QiXhq