### PR TITLE
Add unit tests for pandemic-generator-core

### DIFF
--- a/pandemic-generator-core/build.gradle
+++ b/pandemic-generator-core/build.gradle
@@ -5,6 +5,8 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     api 'com.google.guava:guava:33.0.0-android'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 }
 
 java {

--- a/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/DeckTest.kt
+++ b/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/DeckTest.kt
@@ -1,0 +1,71 @@
+package org.gabbard.pandemicgenerator
+
+import org.junit.Assert.*
+import org.junit.Test
+import java.util.Random
+
+class DeckTest {
+
+    private fun deck(vararg names: String) = Deck(names.map { InfectionCard(City(it, Color.BLUE)) })
+
+    @Test
+    fun drawTakesFromTop() {
+        val (drawn, remaining) = deck("A", "B", "C").draw(2)
+        assertEquals(listOf("A", "B"), drawn.map { it.city.name })
+        assertEquals(listOf("C"), remaining.cards.map { it.city.name })
+    }
+
+    @Test
+    fun drawEntireDeck() {
+        val (drawn, remaining) = deck("A", "B").draw(2)
+        assertEquals(2, drawn.size)
+        assertTrue(remaining.cards.isEmpty())
+    }
+
+    @Test
+    fun drawOneFromBottomReturnsLastCard() {
+        val (card, remaining) = deck("A", "B", "C").drawOneFromTheBottom()
+        assertEquals("C", card.city.name)
+        assertEquals(listOf("A", "B"), remaining.cards.map { it.city.name })
+    }
+
+    @Test
+    fun placeOnTopOf() {
+        val top = deck("A", "B")
+        val bottom = deck("C", "D")
+        val combined = top.placeOnTopOf(bottom)
+        assertEquals(listOf("A", "B", "C", "D"), combined.cards.map { it.city.name })
+    }
+
+    @Test
+    fun shuffledPreservesSize() {
+        val d = deck("A", "B", "C", "D", "E")
+        val shuffled = d.shuffled(Random(42))
+        assertEquals(5, shuffled.cards.size)
+        assertEquals(d.cards.toSet(), shuffled.cards.toSet())
+    }
+
+    @Test
+    fun splitAsEvenlyAsPossibleUsesRoundRobin() {
+        // 6 cards into 3 stacks: card 0→stack0, 1→stack1, 2→stack2, 3→stack0, 4→stack1, 5→stack2
+        val stacks = deck("A", "B", "C", "D", "E", "F").splitAsEvenlyAsPossible(3)
+        assertEquals(3, stacks.size)
+        assertEquals(listOf("A", "D"), stacks[0].map { it.city.name })
+        assertEquals(listOf("B", "E"), stacks[1].map { it.city.name })
+        assertEquals(listOf("C", "F"), stacks[2].map { it.city.name })
+    }
+
+    @Test
+    fun splitHandlesUnevenDivision() {
+        // 7 cards into 3 stacks: stacks 0 and 1 get 3 cards, stack 2 gets 2 (but note:
+        // round-robin means stack0=[0,3,6], stack1=[1,4], stack2=[2,5])
+        // Actually: card6 % 3 == 0, so stack0 gets 3, stacks 1 and 2 get 2 each
+        val stacks = deck("A","B","C","D","E","F","G").splitAsEvenlyAsPossible(3)
+        assertEquals(3, stacks.size)
+        val totalCards = stacks.sumOf { it.size }
+        assertEquals(7, totalCards)
+        // sizes differ by at most 1
+        val sizes = stacks.map { it.size }
+        assertTrue(sizes.max() - sizes.min() <= 1)
+    }
+}

--- a/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/RuleSetTest.kt
+++ b/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/RuleSetTest.kt
@@ -1,0 +1,125 @@
+package org.gabbard.pandemicgenerator
+
+import org.junit.Assert.*
+import org.junit.Test
+import java.util.Random
+
+class RuleSetTest {
+
+    private val rng = Random(42)
+
+    // ── setupGame structural invariants ──────────────────────────────────────
+
+    @Test
+    fun setupGameProducesCorrectNumberOfPlayers() {
+        val game = NATIONAL_CHAMPIONSHIP_RULES.setupGame(rng)
+        assertEquals(2, game.trackableState.players.size)
+    }
+
+    @Test
+    fun allPlayersHaveDistinctRoles() {
+        val game = NATIONAL_CHAMPIONSHIP_RULES.setupGame(rng)
+        val roles = game.trackableState.players.map { it.role }
+        assertEquals(roles.size, roles.toSet().size)
+    }
+
+    @Test
+    fun openingHandsAreFourCards() {
+        val game = NATIONAL_CHAMPIONSHIP_RULES.setupGame(rng)
+        for ((_, hand) in game.untrackableState.hands) {
+            assertEquals(4, hand.size)
+        }
+    }
+
+    @Test
+    fun infectionDeckContainsAllCities() {
+        val game = NATIONAL_CHAMPIONSHIP_RULES.setupGame(rng)
+        val allCitiesInDeckOrDiscard =
+            game.trackableState.infectionDeck.cards.map { it.city }.toSet() +
+            game.trackableState.infectionDiscardPile.map { it.city }.toSet()
+        assertEquals(ALL_CITIES, allCitiesInDeckOrDiscard)
+    }
+
+    @Test
+    fun nineInitialInfectionCardsAreInDiscard() {
+        val game = NATIONAL_CHAMPIONSHIP_RULES.setupGame(rng)
+        assertEquals(9, game.trackableState.infectionDiscardPile.size)
+        assertEquals(ALL_CITIES.size - 9, game.trackableState.infectionDeck.cards.size)
+    }
+
+    @Test
+    fun initialBoardHasCorrectCubeDistribution() {
+        val game = NATIONAL_CHAMPIONSHIP_RULES.setupGame(rng)
+        val board = game.untrackableState.board
+        val cubeCounts = board.cityStates.values.map { it.infections.values.sum() }
+        assertEquals(3, cubeCounts.count { it == 3 })
+        assertEquals(3, cubeCounts.count { it == 2 })
+        assertEquals(3, cubeCounts.count { it == 1 })
+    }
+
+    @Test
+    fun playerDeckContainsCorrectNumberOfEpidemics() {
+        val game = NATIONAL_CHAMPIONSHIP_RULES.setupGame(rng)
+        val epidemicsInDeck = game.trackableState.playerDeck.cards.filterIsInstance<Epidemic>()
+        assertEquals(NATIONAL_CHAMPIONSHIP_RULES.numEpidemicsToUse, epidemicsInDeck.size)
+    }
+
+    @Test
+    fun initialInfectionRateIsInitial() {
+        val game = NATIONAL_CHAMPIONSHIP_RULES.setupGame(rng)
+        assertEquals(InfectionRate.INITIAL, game.trackableState.infectionRate)
+    }
+
+    @Test
+    fun initialLastTransitionIsInfect() {
+        // game starts ready for the player to draw cards
+        val game = NATIONAL_CHAMPIONSHIP_RULES.setupGame(rng)
+        assertEquals(Transition.INFECT, game.trackableState.lastTransition)
+    }
+
+    @Test
+    fun setupIsDeterministicForSameSeed() {
+        val game1 = NATIONAL_CHAMPIONSHIP_RULES.setupGame(Random(99))
+        val game2 = NATIONAL_CHAMPIONSHIP_RULES.setupGame(Random(99))
+        assertEquals(
+            game1.trackableState.players.map { it.role },
+            game2.trackableState.players.map { it.role }
+        )
+        assertEquals(
+            game1.trackableState.infectionDeck.cards,
+            game2.trackableState.infectionDeck.cards
+        )
+    }
+
+    @Test
+    fun setupProducesDifferentGamesForDifferentSeeds() {
+        val game1 = NATIONAL_CHAMPIONSHIP_RULES.setupGame(Random(1))
+        val game2 = NATIONAL_CHAMPIONSHIP_RULES.setupGame(Random(2))
+        // Vanishingly unlikely to be identical
+        assertNotEquals(
+            game1.trackableState.infectionDeck.cards,
+            game2.trackableState.infectionDeck.cards
+        )
+    }
+
+    // ── chooseDistinct ────────────────────────────────────────────────────────
+
+    @Test
+    fun chooseDistinctReturnsRequestedCount() {
+        val items = (1..10).toSet()
+        val chosen = chooseDistinct(items, 4, rng)
+        assertEquals(4, chosen.size)
+    }
+
+    @Test
+    fun chooseDistinctReturnsSubset() {
+        val items = (1..10).toSet()
+        val chosen = chooseDistinct(items, 4, rng)
+        assertTrue(items.containsAll(chosen))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun chooseDistinctThrowsWhenNotEnoughItems() {
+        chooseDistinct(setOf(1, 2), 5, rng)
+    }
+}

--- a/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/TrackableStateTest.kt
+++ b/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/TrackableStateTest.kt
@@ -1,0 +1,195 @@
+package org.gabbard.pandemicgenerator
+
+import org.junit.Assert.*
+import org.junit.Test
+import java.util.Random
+
+class TrackableStateTest {
+
+    private val rng = Random(0)
+
+    private fun makeState(
+        infectionDeckCities: List<City> = ALL_CITIES.take(10).toList(),
+        discardCities: Set<City> = ALL_CITIES.drop(10).toSet(),
+        playerCards: List<PlayerCard> = listOf(SimpleEpidemic(), SimpleEpidemic()),
+        infectionRate: InfectionRate = InfectionRate.INITIAL,
+        lastTransition: Transition = Transition.DRAW_PLAYER_CARDS
+    ): TrackableState {
+        val players = listOf(Player(Role("Medic")), Player(Role("Scientist")))
+        return TrackableState(
+            curPlayer = 0,
+            players = players,
+            infectionDeck = Deck(infectionDeckCities.map { InfectionCard(it) }),
+            infectionDiscardPile = discardCities.map { InfectionCard(it) }.toSet(),
+            playerDeck = Deck(playerCards),
+            infectionRate = infectionRate,
+            lastTransition = lastTransition
+        )
+    }
+
+    // ── legalTransitions ────────────────────────────────────────────────────
+
+    @Test
+    fun afterInfectOnlyDrawIsLegal() {
+        val state = makeState(lastTransition = Transition.INFECT)
+        assertEquals(setOf(Transition.DRAW_PLAYER_CARDS), state.legalTransitions())
+    }
+
+    @Test
+    fun afterDrawOnlyInfectIsLegal() {
+        val state = makeState(lastTransition = Transition.DRAW_PLAYER_CARDS)
+        assertEquals(setOf(Transition.INFECT), state.legalTransitions())
+    }
+
+    // ── infect transition ────────────────────────────────────────────────────
+
+    @Test
+    fun infectDrawsCorrectNumberOfCards() {
+        val state = makeState(lastTransition = Transition.DRAW_PLAYER_CARDS,
+            infectionRate = InfectionRate.INITIAL)
+        val result = state.executeTransition(Transition.INFECT, rng)
+                as TrackableState.TransitionResult.InfectionTransitionResult
+        assertEquals(InfectionRate.INITIAL.numInfectionCardsToDraw, result.infectedCities.size)
+    }
+
+    @Test
+    fun infectMovesCardsToDiscard() {
+        val infectionCities = ALL_CITIES.take(10).toList()
+        val discardCities = ALL_CITIES.drop(10).toSet()
+        val state = makeState(
+            infectionDeckCities = infectionCities,
+            discardCities = discardCities,
+            lastTransition = Transition.DRAW_PLAYER_CARDS
+        )
+        val result = state.executeTransition(Transition.INFECT, rng)
+                as TrackableState.TransitionResult.InfectionTransitionResult
+        val newState = result.newGameState
+
+        // drawn cities moved from deck to discard
+        val numDrawn = InfectionRate.INITIAL.numInfectionCardsToDraw
+        assertEquals(infectionCities.size - numDrawn, newState.infectionDeck.cards.size)
+        assertTrue(newState.infectionDiscardPile.map { it.city }.containsAll(result.infectedCities))
+    }
+
+    @Test
+    fun infectCitiesAreTopOfDeck() {
+        val cities = ALL_CITIES.take(10).toList()
+        val state = makeState(
+            infectionDeckCities = cities,
+            discardCities = ALL_CITIES.drop(10).toSet(),
+            lastTransition = Transition.DRAW_PLAYER_CARDS
+        )
+        val result = state.executeTransition(Transition.INFECT, rng)
+                as TrackableState.TransitionResult.InfectionTransitionResult
+        val numDrawn = InfectionRate.INITIAL.numInfectionCardsToDraw
+        assertEquals(cities.take(numDrawn), result.infectedCities)
+    }
+
+    @Test
+    fun infectSetsLastTransition() {
+        val state = makeState(lastTransition = Transition.DRAW_PLAYER_CARDS)
+        val result = state.executeTransition(Transition.INFECT, rng)
+        assertEquals(Transition.INFECT, result.newGameState.lastTransition)
+    }
+
+    // ── draw player cards transition ─────────────────────────────────────────
+
+    @Test
+    fun drawPlayerCardsDrawsTwo() {
+        val cityCards = ALL_CITIES.take(5).map { CityPlayerCard(it) }
+        val state = makeState(playerCards = cityCards, lastTransition = Transition.INFECT)
+        val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.DrawPlayerCardsTransitionResult
+        assertEquals(2, result.cardsDrawn.size)
+        assertEquals(3, result.newGameState.playerDeck.cards.size)
+    }
+
+    @Test
+    fun drawPlayerCardsSetsLastTransition() {
+        val cityCards = ALL_CITIES.take(5).map { CityPlayerCard(it) }
+        val state = makeState(playerCards = cityCards, lastTransition = Transition.INFECT)
+        val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+        assertEquals(Transition.DRAW_PLAYER_CARDS, result.newGameState.lastTransition)
+    }
+
+    @Test
+    fun drawWithNoEpidemicsHasEmptyEpidemicList() {
+        val cityCards = ALL_CITIES.take(5).map { CityPlayerCard(it) }
+        val state = makeState(playerCards = cityCards, lastTransition = Transition.INFECT)
+        val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.DrawPlayerCardsTransitionResult
+        assertTrue(result.epidemicsAndInfectedCities.isEmpty())
+    }
+
+    // ── epidemic execution ────────────────────────────────────────────────────
+
+    @Test
+    fun epidemicAdvancesInfectionRate() {
+        val epidemic = NamedEpidemic("Test Epidemic")
+        val cityCards = listOf(epidemic) + ALL_CITIES.take(4).map { CityPlayerCard(it) }
+        val state = makeState(
+            playerCards = cityCards,
+            infectionRate = InfectionRate.INITIAL,
+            lastTransition = Transition.INFECT
+        )
+        val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.DrawPlayerCardsTransitionResult
+        assertEquals(InfectionRate.STEP_TWO, result.newGameState.infectionRate)
+    }
+
+    @Test
+    fun epidemicClearsDiscardPile() {
+        val epidemic = NamedEpidemic("Test Epidemic")
+        val cityCards = listOf(epidemic) + ALL_CITIES.take(4).map { CityPlayerCard(it) }
+        val state = makeState(
+            playerCards = cityCards,
+            lastTransition = Transition.INFECT
+        )
+        val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.DrawPlayerCardsTransitionResult
+        assertTrue(result.newGameState.infectionDiscardPile.isEmpty())
+    }
+
+    @Test
+    fun epidemicInfectsCityFromBottomOfDeck() {
+        val epidemic = NamedEpidemic("Test Epidemic")
+        val cityCards = listOf(epidemic) + ALL_CITIES.take(4).map { CityPlayerCard(it) }
+        val infectionCities = ALL_CITIES.take(10).toList()
+        val state = makeState(
+            playerCards = cityCards,
+            infectionDeckCities = infectionCities,
+            discardCities = ALL_CITIES.drop(10).toSet(),
+            lastTransition = Transition.INFECT
+        )
+        val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.DrawPlayerCardsTransitionResult
+        // bottom of deck = last element
+        val expectedCity = infectionCities.last()
+        assertEquals(1, result.epidemicsAndInfectedCities.size)
+        assertEquals(expectedCity, result.epidemicsAndInfectedCities[0].second)
+    }
+
+    @Test
+    fun epidemicShufflesDiscardOntoTopOfDeck() {
+        val epidemic = NamedEpidemic("Test Epidemic")
+        val cityCards = listOf(epidemic) + ALL_CITIES.take(4).map { CityPlayerCard(it) }
+        val infectionCities = ALL_CITIES.take(10).toList()
+        val discardCities = ALL_CITIES.drop(10).toSet()
+        val state = makeState(
+            playerCards = cityCards,
+            infectionDeckCities = infectionCities,
+            discardCities = discardCities,
+            lastTransition = Transition.INFECT
+        )
+        val preDeckSize = infectionCities.size
+        val preDiscardSize = discardCities.size
+
+        val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.DrawPlayerCardsTransitionResult
+        val newDeck = result.newGameState.infectionDeck
+
+        // new deck = old discard (shuffled) + old bottom-card + remaining deck cards
+        // size = preDiscard + 1 + (preDeck - 1) = preDiscard + preDeck
+        assertEquals(preDiscardSize + preDeckSize, newDeck.cards.size)
+    }
+}


### PR DESCRIPTION
Adds JUnit test infrastructure and 34 tests to `pandemic-generator-core`.

## Summary
- Add `junit` and `kotlin-test` to `testImplementation` in `pandemic-generator-core/build.gradle`
- **`DeckTest`** (8 tests) — `draw`, `drawOneFromTheBottom`, `placeOnTopOf`, `shuffled`, `splitAsEvenlyAsPossible` including uneven division
- **`TrackableStateTest`** (16 tests) — legal transition alternation; infect draws correct count, moves cards to discard, uses top of deck; draw player cards draws two, handles no-epidemic case; epidemic advances infection rate, clears discard pile, infects city from bottom of deck, shuffles discard onto top
- **`RuleSetTest`** (10 tests) — `setupGame` structural invariants (player count, distinct roles, 4-card hands, all cities accounted for, 9 initial infection cards, correct cube distribution, epidemic count, initial rate/transition); determinism for same seed; `chooseDistinct` correctness and error handling

## Test plan
- `./gradlew :pandemic-generator-core:test` — all 34 pass, no warnings

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ly2HhdYNtAAkr2cgKL7AWa)_