### PR TITLE
Prettier timer screen

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
@@ -39,7 +39,7 @@ class TurnTimer : AppCompatActivity() {
             val timeTilTarget = targetTime - SystemClock.elapsedRealtime()
             if (timeTilTarget <= 0) {
                 try {
-                    val notification = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+                    val notification = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
                     val r = RingtoneManager.getRingtone(applicationContext, notification)
                     r.play()
                     binding.timeRemaining.stop()

--- a/app/src/main/res/layout/activity_turn_timer.xml
+++ b/app/src/main/res/layout/activity_turn_timer.xml
@@ -8,19 +8,25 @@
 
     <Chronometer
         android:id="@+id/timeRemaining"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="TextView"
-        tools:layout_editor_absoluteX="144dp"
-        tools:layout_editor_absoluteY="86dp" />
+        android:gravity="center"
+        android:textSize="96sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@+id/drawPlayerCards"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/drawPlayerCards"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="124dp"
+        android:layout_marginBottom="48dp"
         android:onClick="onDrawPlayerCards"
         android:text="Draw Player Cards"
-        app:layout_constraintTop_toBottomOf="@+id/timeRemaining"
-        tools:layout_editor_absoluteX="109dp" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- Timer is now 96sp bold text, centered horizontally and vertically between the top of the screen and the button
- "Draw Player Cards" button is pinned to the bottom center
- Time's-up sound changed from the quiet notification tone to the device's alarm tone

Both changes are layout/config only — no logic touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ly2HhdYNtAAkr2cgKL7AWa)_