### PR TITLE
Add random seed option; show seed on all game screens

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
@@ -14,10 +14,12 @@ class DrawPlayerCards : AppCompatActivity() {
     private lateinit var binding: ActivityDrawPlayerCardsBinding
     private var gameState: TrackableState? = null
     private var rng: Random? = null
+    private var seed: Long = 0
 
     companion object {
         const val GAME_STATE = "game_state"
         const val RANDOM_SOURCE = "random_source"
+        const val SEED = "seed"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -28,16 +30,19 @@ class DrawPlayerCards : AppCompatActivity() {
         gameState = intent.getSerializableExtra(DrawPlayerCards.GAME_STATE) as TrackableState
         @Suppress("DEPRECATION")
         rng = intent.getSerializableExtra(DrawPlayerCards.RANDOM_SOURCE) as Random
-        val drawResult = gameState!!.executeTransition(Transition.DRAW_PLAYER_CARDS, rng!!)
+        seed = intent.getLongExtra(SEED, 0)
+        binding.seedDisplay.text = "Seed: $seed"
 
+        val drawResult = gameState!!.executeTransition(Transition.DRAW_PLAYER_CARDS, rng!!)
         gameState = drawResult.newGameState
         binding.drawResultMessage.text = messageForTransitionResult(drawResult)
     }
 
     fun onProceedToInfectionPhase(@Suppress("UNUSED_PARAMETER") view: View) {
-        val infetionIntent = Intent(this, InfectionActivity::class.java)
-        infetionIntent.putExtra(InfectionActivity.GAME_STATE, gameState!!)
-        infetionIntent.putExtra(InfectionActivity.RANDOM_SOURCE, rng!!)
-        startActivity(infetionIntent)
+        val infectionIntent = Intent(this, InfectionActivity::class.java)
+        infectionIntent.putExtra(InfectionActivity.GAME_STATE, gameState!!)
+        infectionIntent.putExtra(InfectionActivity.RANDOM_SOURCE, rng!!)
+        infectionIntent.putExtra(InfectionActivity.SEED, seed)
+        startActivity(infectionIntent)
     }
 }

--- a/app/src/main/java/gabbard/org/pandemicgenerator/EnterRandomSeed.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/EnterRandomSeed.kt
@@ -6,6 +6,7 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import gabbard.org.pandemicgenerator.databinding.ActivityEnterRandomSeedBinding
 import java.util.*
+import kotlin.math.abs
 
 class EnterRandomSeed : AppCompatActivity() {
     private lateinit var binding: ActivityEnterRandomSeedBinding
@@ -14,13 +15,18 @@ class EnterRandomSeed : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityEnterRandomSeedBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        binding.randomSeedButton.setOnClickListener {
+            val seed = abs(Random().nextLong()) % 1_000_000L
+            binding.startGame.setText(seed.toString())
+        }
     }
 
     fun startGame(@Suppress("UNUSED_PARAMETER") view: View) {
-        val rng = Random(binding.startGame.text.toString().toLong())
-
+        val seed = binding.startGame.text.toString().toLong()
         val startGameIntent = Intent(this, InitialSetup::class.java)
-        startGameIntent.putExtra(InitialSetup.RANDOM_SOURCE, rng)
+        startGameIntent.putExtra(InitialSetup.RANDOM_SOURCE, Random(seed))
+        startGameIntent.putExtra(InitialSetup.SEED, seed)
         startActivity(startGameIntent)
     }
 }

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
@@ -12,12 +12,14 @@ import java.util.*
 
 class InfectionActivity : AppCompatActivity() {
     private lateinit var binding: ActivityInfectionBinding
-    var gameState: TrackableState? = null
-    var rng: Random? = null
+    private var gameState: TrackableState? = null
+    private var rng: Random? = null
+    private var seed: Long = 0
 
     companion object {
         const val GAME_STATE = "game_state"
         const val RANDOM_SOURCE = "random_source"
+        const val SEED = "seed"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -28,6 +30,8 @@ class InfectionActivity : AppCompatActivity() {
         gameState = intent.getSerializableExtra(InfectionActivity.GAME_STATE) as TrackableState
         @Suppress("DEPRECATION")
         rng = intent.getSerializableExtra(InfectionActivity.RANDOM_SOURCE) as Random
+        seed = intent.getLongExtra(SEED, 0)
+        binding.seedDisplay.text = "Seed: $seed"
 
         val infectionResult = gameState!!.executeTransition(Transition.INFECT, rng!!)
         binding.infectionResultMessage.text = messageForTransitionResult(infectionResult)
@@ -38,6 +42,7 @@ class InfectionActivity : AppCompatActivity() {
         val turnTimerIntent = Intent(this, TurnTimer::class.java)
         turnTimerIntent.putExtra(TurnTimer.GAME_STATE, gameState!!)
         turnTimerIntent.putExtra(TurnTimer.RANDOM_SOURCE, rng!!)
+        turnTimerIntent.putExtra(TurnTimer.SEED, seed)
         startActivity(turnTimerIntent)
     }
 }

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InitialSetup.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InitialSetup.kt
@@ -14,9 +14,11 @@ class InitialSetup : AppCompatActivity() {
     private lateinit var binding: ActivityInitialSetupBinding
     private var gameState: TrackableState? = null
     private var rng: Random? = null
+    private var seed: Long = 0
 
     companion object {
         const val RANDOM_SOURCE = "random_source"
+        const val SEED = "seed"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -25,6 +27,8 @@ class InitialSetup : AppCompatActivity() {
         setContentView(binding.root)
         @Suppress("DEPRECATION")
         rng = intent.getSerializableExtra(RANDOM_SOURCE) as Random
+        seed = intent.getLongExtra(SEED, 0)
+        binding.seedDisplay.text = "Seed: $seed"
 
         val fullGameState = NATIONAL_CHAMPIONSHIP_RULES.setupGame(rng!!)
         gameState = fullGameState.trackableState
@@ -43,6 +47,7 @@ class InitialSetup : AppCompatActivity() {
         val turnTimerIntent = Intent(this, TurnTimer::class.java)
         turnTimerIntent.putExtra(TurnTimer.GAME_STATE, gameState)
         turnTimerIntent.putExtra(TurnTimer.RANDOM_SOURCE, rng)
+        turnTimerIntent.putExtra(TurnTimer.SEED, seed)
         startActivity(turnTimerIntent)
     }
 }

--- a/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
@@ -17,10 +17,12 @@ class TurnTimer : AppCompatActivity() {
     private lateinit var binding: ActivityTurnTimerBinding
     private var gameState: TrackableState? = null
     private var rng: Random? = null
+    private var seed: Long = 0
 
     companion object {
         const val GAME_STATE = "game_state"
         const val RANDOM_SOURCE = "random_source"
+        const val SEED = "seed"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -31,6 +33,9 @@ class TurnTimer : AppCompatActivity() {
         gameState = intent.getSerializableExtra(GAME_STATE) as TrackableState
         @Suppress("DEPRECATION")
         rng = intent.getSerializableExtra(RANDOM_SOURCE) as Random
+        seed = intent.getLongExtra(SEED, 0)
+        binding.seedDisplay.text = "Seed: $seed"
+
         binding.timeRemaining.isCountDown = true
         binding.timeRemaining.start()
         val targetTime = SystemClock.elapsedRealtime() + 75 * 1000
@@ -58,6 +63,7 @@ class TurnTimer : AppCompatActivity() {
         val drawPlayerCardsIntent = Intent(this, DrawPlayerCards::class.java)
         drawPlayerCardsIntent.putExtra(DrawPlayerCards.GAME_STATE, gameState!!)
         drawPlayerCardsIntent.putExtra(DrawPlayerCards.RANDOM_SOURCE, rng!!)
+        drawPlayerCardsIntent.putExtra(DrawPlayerCards.SEED, seed)
         startActivity(drawPlayerCardsIntent)
     }
 }

--- a/app/src/main/res/layout/activity_draw_player_cards.xml
+++ b/app/src/main/res/layout/activity_draw_player_cards.xml
@@ -8,19 +8,35 @@
 
     <TextView
         android:id="@+id/drawResultMessage"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
         android:text="TextView"
-        tools:layout_editor_absoluteX="163dp"
-        tools:layout_editor_absoluteY="85dp" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/proceedToInfectionPhase"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="284dp"
+        android:layout_marginBottom="48dp"
         android:onClick="onProceedToInfectionPhase"
         android:text="Proceed to Infection Phase"
-        app:layout_constraintTop_toBottomOf="@+id/drawResultMessage"
-        tools:layout_editor_absoluteX="97dp" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/seedDisplay"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        android:textSize="11sp"
+        android:alpha="0.5"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_enter_random_seed.xml
+++ b/app/src/main/res/layout/activity_enter_random_seed.xml
@@ -6,25 +6,17 @@
     android:layout_height="match_parent"
     tools:context=".EnterRandomSeed">
 
-    <Button
-        android:id="@+id/button2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:onClick="startGame"
-        android:text="Start Game with Seed"
-        app:layout_constraintTop_toBottomOf="@+id/startGame"
-        tools:layout_editor_absoluteX="99dp" />
-
     <TextView
         android:id="@+id/textView"
         android:layout_width="wrap_content"
-        android:layout_height="0dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginRight="8dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
         android:text="Enter random seed"
-        app:layout_constraintEnd_toStartOf="@+id/startGame"
-        tools:layout_editor_absoluteY="246dp" />
+        app:layout_constraintBottom_toTopOf="@+id/startGame"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed" />
 
     <EditText
         android:id="@+id/startGame"
@@ -32,7 +24,33 @@
         android:layout_height="wrap_content"
         android:ems="10"
         android:inputType="number"
-        tools:layout_editor_absoluteX="153dp"
-        tools:layout_editor_absoluteY="232dp" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/randomSeedButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="8dp"
+        android:text="Random Seed"
+        app:layout_constraintEnd_toStartOf="@+id/button2"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/startGame" />
+
+    <Button
+        android:id="@+id/button2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginStart="8dp"
+        android:onClick="startGame"
+        android:text="Start Game"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/randomSeedButton"
+        app:layout_constraintTop_toBottomOf="@+id/startGame" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_infection.xml
+++ b/app/src/main/res/layout/activity_infection.xml
@@ -8,19 +8,35 @@
 
     <TextView
         android:id="@+id/infectionResultMessage"
-        android:layout_width="wrap_content"
-        android:layout_height="17dp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
         android:text="TextView"
-        tools:layout_editor_absoluteX="134dp"
-        tools:layout_editor_absoluteY="90dp" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/nextTurn"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="164dp"
+        android:layout_marginBottom="48dp"
         android:onClick="onNextTurn"
         android:text="Next Turn"
-        app:layout_constraintTop_toBottomOf="@+id/infectionResultMessage"
-        tools:layout_editor_absoluteX="148dp" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/seedDisplay"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        android:textSize="11sp"
+        android:alpha="0.5"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_initial_setup.xml
+++ b/app/src/main/res/layout/activity_initial_setup.xml
@@ -7,38 +7,56 @@
     tools:context=".InitialSetup">
 
     <TextView
-        android:id="@+id/player1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="40dp"
-        android:text="TextView"
-        app:layout_constraintTop_toBottomOf="@+id/player2"
-        tools:layout_editor_absoluteX="29dp" />
-
-    <TextView
         android:id="@+id/player2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginStart="16dp"
         android:text="TextView"
-        tools:layout_editor_absoluteX="48dp"
-        tools:layout_editor_absoluteY="16dp" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/player1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginStart="16dp"
+        android:text="TextView"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/player2" />
 
     <TextView
         android:id="@+id/board"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="52dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
         android:text="TextView"
-        app:layout_constraintTop_toBottomOf="@+id/player1"
-        tools:layout_editor_absoluteX="29dp" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/player1" />
 
     <Button
         android:id="@+id/button3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="268dp"
+        android:layout_marginBottom="48dp"
         android:onClick="readyToPlay"
         android:text="Ready to Play"
-        app:layout_constraintTop_toBottomOf="@+id/board"
-        tools:layout_editor_absoluteX="74dp" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/seedDisplay"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        android:textSize="11sp"
+        android:alpha="0.5"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -11,7 +12,9 @@
         android:layout_height="wrap_content"
         android:onClick="startGame"
         android:text="Start Game"
-        tools:layout_editor_absoluteX="148dp"
-        tools:layout_editor_absoluteY="309dp" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_turn_timer.xml
+++ b/app/src/main/res/layout/activity_turn_timer.xml
@@ -29,4 +29,14 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
+    <TextView
+        android:id="@+id/seedDisplay"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        android:textSize="11sp"
+        android:alpha="0.5"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- **Random seed button**: on the seed entry screen, tapping "Random Seed" fills the field with a random 6-digit number so you don't have to think of one yourself — you can still edit it before starting
- **Seed display**: from `InitialSetup` onwards, every screen shows `Seed: N` in small faded text in the bottom-right corner, so you can always note it down to replay a game
- The seed flows as a `Long` through the full intent chain: `EnterRandomSeed → InitialSetup → TurnTimer → DrawPlayerCards → InfectionActivity → TurnTimer → …`
- Fixed all layouts: replaced editor-only `tools:layout_editor_absolute*` attributes (which did nothing at runtime) with real ConstraintLayout constraints

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ly2HhdYNtAAkr2cgKL7AWa)_