### PR TITLE
Display infection cards with disease color indicators

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/CityDisplay.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/CityDisplay.kt
@@ -1,0 +1,79 @@
+package gabbard.org.pandemicgenerator
+
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
+import android.view.Gravity
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+import org.gabbard.pandemicgenerator.City
+import org.gabbard.pandemicgenerator.CityPlayerCard
+import org.gabbard.pandemicgenerator.Epidemic
+import org.gabbard.pandemicgenerator.EventCard
+import org.gabbard.pandemicgenerator.PlayerCard
+import org.gabbard.pandemicgenerator.Color as GameColor
+
+fun GameColor.toAndroidColor(): Int = when (this) {
+    GameColor.BLUE   -> android.graphics.Color.rgb(25,  118, 210)  // Blue 700
+    GameColor.YELLOW -> android.graphics.Color.rgb(255, 160,   0)  // Amber 700
+    GameColor.BLACK  -> android.graphics.Color.rgb(66,   66,  66)  // Grey 800
+    GameColor.RED    -> android.graphics.Color.rgb(211,  47,  47)  // Red 700
+}
+
+private fun LinearLayout.addDotRow(dotColor: Int, label: String, detail: String? = null) {
+    val dp = context.resources.displayMetrics.density
+    val row = LinearLayout(context).apply {
+        orientation = LinearLayout.HORIZONTAL
+        gravity = Gravity.CENTER_VERTICAL
+        setPadding(0, (6 * dp).toInt(), 0, (6 * dp).toInt())
+    }
+
+    val dot = View(context).apply {
+        layoutParams = LinearLayout.LayoutParams((18 * dp).toInt(), (18 * dp).toInt()).also {
+            it.marginEnd = (12 * dp).toInt()
+        }
+        background = GradientDrawable().apply {
+            shape = GradientDrawable.OVAL
+            setColor(dotColor)
+        }
+    }
+
+    val nameView = TextView(context).apply {
+        text = label
+        textSize = 16f
+        layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+    }
+
+    row.addView(dot)
+    row.addView(nameView)
+
+    if (detail != null) {
+        row.addView(TextView(context).apply {
+            text = detail
+            textSize = 13f
+            setTextColor(android.graphics.Color.GRAY)
+        })
+    }
+
+    addView(row)
+}
+
+fun LinearLayout.addCityRow(city: City, detail: String? = null) =
+    addDotRow(city.color.toAndroidColor(), city.name, detail)
+
+fun LinearLayout.addPlayerCardRow(card: PlayerCard) = when (card) {
+    is CityPlayerCard -> addCityRow(card.city)
+    is EventCard      -> addDotRow(android.graphics.Color.rgb(56, 142, 60), card.name)  // Green 700
+    is Epidemic       -> addDotRow(android.graphics.Color.rgb(183, 28, 28), card.userString)  // Red 900
+}
+
+fun LinearLayout.addSectionHeader(text: String) {
+    val dp = context.resources.displayMetrics.density
+    addView(TextView(context).apply {
+        this.text = text
+        textSize = 12f
+        setTypeface(null, Typeface.BOLD)
+        setTextColor(android.graphics.Color.GRAY)
+        setPadding(0, (14 * dp).toInt(), 0, (4 * dp).toInt())
+    })
+}

--- a/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
@@ -7,7 +7,6 @@ import androidx.appcompat.app.AppCompatActivity
 import gabbard.org.pandemicgenerator.databinding.ActivityDrawPlayerCardsBinding
 import org.gabbard.pandemicgenerator.TrackableState
 import org.gabbard.pandemicgenerator.Transition
-import org.gabbard.pandemicgenerator.messageForTransitionResult
 import java.util.*
 
 class DrawPlayerCards : AppCompatActivity() {
@@ -33,9 +32,18 @@ class DrawPlayerCards : AppCompatActivity() {
         seed = intent.getLongExtra(SEED, 0)
         binding.seedDisplay.text = "Seed: $seed"
 
-        val drawResult = gameState!!.executeTransition(Transition.DRAW_PLAYER_CARDS, rng!!)
-        gameState = drawResult.newGameState
-        binding.drawResultMessage.text = messageForTransitionResult(drawResult)
+        val result = gameState!!.executeTransition(Transition.DRAW_PLAYER_CARDS, rng!!)
+                as TrackableState.TransitionResult.DrawPlayerCardsTransitionResult
+        gameState = result.newGameState
+
+        val container = binding.cardsContainer
+        container.addSectionHeader("Cards drawn:")
+        result.cardsDrawn.forEach { container.addPlayerCardRow(it) }
+
+        for ((epidemic, city) in result.epidemicsAndInfectedCities) {
+            container.addSectionHeader("Epidemic: ${epidemic.userString}")
+            container.addCityRow(city, "infected from bottom")
+        }
     }
 
     fun onProceedToInfectionPhase(@Suppress("UNUSED_PARAMETER") view: View) {

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
@@ -7,7 +7,6 @@ import androidx.appcompat.app.AppCompatActivity
 import gabbard.org.pandemicgenerator.databinding.ActivityInfectionBinding
 import org.gabbard.pandemicgenerator.TrackableState
 import org.gabbard.pandemicgenerator.Transition
-import org.gabbard.pandemicgenerator.messageForTransitionResult
 import java.util.*
 
 class InfectionActivity : AppCompatActivity() {
@@ -33,9 +32,12 @@ class InfectionActivity : AppCompatActivity() {
         seed = intent.getLongExtra(SEED, 0)
         binding.seedDisplay.text = "Seed: $seed"
 
-        val infectionResult = gameState!!.executeTransition(Transition.INFECT, rng!!)
-        binding.infectionResultMessage.text = messageForTransitionResult(infectionResult)
-        gameState = infectionResult.newGameState
+        val result = gameState!!.executeTransition(Transition.INFECT, rng!!)
+                as TrackableState.TransitionResult.InfectionTransitionResult
+        gameState = result.newGameState
+
+        binding.infectedCities.addSectionHeader("Cities infected this turn:")
+        result.infectedCities.forEach { binding.infectedCities.addCityRow(it) }
     }
 
     fun onNextTurn(@Suppress("UNUSED_PARAMETER") view: View) {

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InitialSetup.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InitialSetup.kt
@@ -40,7 +40,16 @@ class InitialSetup : AppCompatActivity() {
         val hands = fullGameState.untrackableState.hands
         binding.player1.text = players[0].role.name + ": " + hands[players[0]]
         binding.player2.text = players[1].role.name + ": " + hands[players[1]]
-        binding.board.text = fullGameState.untrackableState.board.cityStates.toString()
+
+        val boardCities = binding.boardCities
+        val cityStates = fullGameState.untrackableState.board.cityStates
+        for (cubes in 3 downTo 1) {
+            val cities = cityStates.filterValues { it.infections.values.sum() == cubes }.keys
+            if (cities.isNotEmpty()) {
+                boardCities.addSectionHeader("$cubes cube${if (cubes == 1) "" else "s"}:")
+                cities.sortedBy { it.name }.forEach { boardCities.addCityRow(it) }
+            }
+        }
     }
 
     fun readyToPlay(@Suppress("UNUSED_PARAMETER") view: View) {

--- a/app/src/main/res/layout/activity_draw_player_cards.xml
+++ b/app/src/main/res/layout/activity_draw_player_cards.xml
@@ -6,17 +6,23 @@
     android:layout_height="match_parent"
     tools:context=".DrawPlayerCards">
 
-    <TextView
-        android:id="@+id/drawResultMessage"
+    <ScrollView
+        android:id="@+id/scrollView"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:text="TextView"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/proceedToInfectionPhase"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <LinearLayout
+            android:id="@+id/cardsContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp" />
+
+    </ScrollView>
 
     <Button
         android:id="@+id/proceedToInfectionPhase"
@@ -33,9 +39,9 @@
         android:id="@+id/seedDisplay"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:alpha="0.5"
         android:padding="8dp"
         android:textSize="11sp"
-        android:alpha="0.5"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/layout/activity_infection.xml
+++ b/app/src/main/res/layout/activity_infection.xml
@@ -6,14 +6,14 @@
     android:layout_height="match_parent"
     tools:context=".InfectionActivity">
 
-    <TextView
-        android:id="@+id/infectionResultMessage"
+    <LinearLayout
+        android:id="@+id/infectedCities"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="32dp"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
-        android:text="TextView"
+        android:orientation="vertical"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -33,9 +33,9 @@
         android:id="@+id/seedDisplay"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:alpha="0.5"
         android:padding="8dp"
         android:textSize="11sp"
-        android:alpha="0.5"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/layout/activity_initial_setup.xml
+++ b/app/src/main/res/layout/activity_initial_setup.xml
@@ -6,37 +6,51 @@
     android:layout_height="match_parent"
     tools:context=".InitialSetup">
 
-    <TextView
-        android:id="@+id/player2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:layout_marginStart="16dp"
-        android:text="TextView"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-        android:id="@+id/player1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:layout_marginStart="16dp"
-        android:text="TextView"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/player2" />
-
-    <TextView
-        android:id="@+id/board"
+    <ScrollView
+        android:id="@+id/scrollView"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:text="TextView"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/button3"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/player1" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/player1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="15sp"
+                tools:text="Medic: [Bangkok, Shanghai]" />
+
+            <TextView
+                android:id="@+id/player2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textSize="15sp"
+                tools:text="Scientist: [Tokyo, Cairo]" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginTop="12dp"
+                android:layout_marginBottom="4dp"
+                android:background="#1F000000" />
+
+            <LinearLayout
+                android:id="@+id/boardCities"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+
+        </LinearLayout>
+    </ScrollView>
 
     <Button
         android:id="@+id/button3"
@@ -53,9 +67,9 @@
         android:id="@+id/seedDisplay"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:alpha="0.5"
         android:padding="8dp"
         android:textSize="11sp"
-        android:alpha="0.5"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 


### PR DESCRIPTION
## Summary
Replaces the raw `toString()` text on three screens with structured visual rows: a filled circle in the disease color followed by the city name.

**`CityDisplay.kt`** — new shared helper file with `LinearLayout` extension functions:
- `addCityRow(city)` — colored dot + city name
- `addPlayerCardRow(card)` — handles city cards (disease color), event cards (green), epidemic cards (dark red)
- `addSectionHeader(text)` — small bold grey label

**InitialSetup** — board grouped by cube count (3 / 2 / 1 cubes), each city shown with its disease color dot; wrapped in a `ScrollView` since 9 cities can overflow on small screens

**InfectionActivity** — infected cities shown as colored rows under a "Cities infected this turn:" header

**DrawPlayerCards** — cards drawn shown by type; epidemic effect shows the bottom-of-deck city with its disease color and an "infected from bottom" label

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ly2HhdYNtAAkr2cgKL7AWa)_