### PR TITLE
Display initial player hands as colored card rows

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/InitialSetup.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InitialSetup.kt
@@ -38,8 +38,11 @@ class InitialSetup : AppCompatActivity() {
             throw RuntimeException("Only two players currently supported. Issue #10")
         }
         val hands = fullGameState.untrackableState.hands
-        binding.player1.text = players[0].role.name + ": " + hands[players[0]]
-        binding.player2.text = players[1].role.name + ": " + hands[players[1]]
+        listOf(binding.player1Cards to players[0], binding.player2Cards to players[1])
+            .forEach { (container, player) ->
+                container.addSectionHeader(player.role.name)
+                hands[player]!!.sortedBy { it.userString }.forEach { container.addPlayerCardRow(it) }
+            }
 
         val boardCities = binding.boardCities
         val cityStates = fullGameState.untrackableState.board.cityStates

--- a/app/src/main/res/layout/activity_initial_setup.xml
+++ b/app/src/main/res/layout/activity_initial_setup.xml
@@ -21,20 +21,18 @@
             android:orientation="vertical"
             android:padding="16dp">
 
-            <TextView
-                android:id="@+id/player1"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:id="@+id/player1Cards"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textSize="15sp"
-                tools:text="Medic: [Bangkok, Shanghai]" />
+                android:orientation="vertical" />
 
-            <TextView
-                android:id="@+id/player2"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:id="@+id/player2Cards"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:textSize="15sp"
-                tools:text="Scientist: [Tokyo, Cairo]" />
+                android:layout_marginTop="8dp"
+                android:orientation="vertical" />
 
             <View
                 android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
Replaces the "Medic: [Bangkok, Shanghai, ...]" text strings with the same structured colored-dot rows used for infection cards.

Each player section now shows the role name as a section header, followed by one row per card — city cards with their disease color dot, event cards in green. Cards are sorted alphabetically within each hand for consistency.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ly2HhdYNtAAkr2cgKL7AWa)_