### PR TITLE
Add game persistence and End Game option

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
@@ -3,13 +3,12 @@ package gabbard.org.pandemicgenerator
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import gabbard.org.pandemicgenerator.databinding.ActivityDrawPlayerCardsBinding
 import org.gabbard.pandemicgenerator.TrackableState
 import org.gabbard.pandemicgenerator.Transition
 import java.util.*
 
-class DrawPlayerCards : AppCompatActivity() {
+class DrawPlayerCards : GameActivity() {
     private lateinit var binding: ActivityDrawPlayerCardsBinding
     private var gameState: TrackableState? = null
     private var rng: Random? = null

--- a/app/src/main/java/gabbard/org/pandemicgenerator/GameActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/GameActivity.kt
@@ -1,0 +1,33 @@
+package gabbard.org.pandemicgenerator
+
+import android.app.AlertDialog
+import android.content.Intent
+import android.view.Menu
+import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
+
+abstract class GameActivity : AppCompatActivity() {
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.menu_game, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {
+        R.id.action_end_game -> {
+            AlertDialog.Builder(this)
+                .setTitle("End Game")
+                .setMessage("Are you sure you want to abandon this game?")
+                .setPositiveButton("End Game") { _, _ ->
+                    GameRepository.clear(this)
+                    startActivity(Intent(this, MainActivity::class.java).apply {
+                        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                    })
+                }
+                .setNegativeButton("Cancel", null)
+                .show()
+            true
+        }
+        else -> super.onOptionsItemSelected(item)
+    }
+}

--- a/app/src/main/java/gabbard/org/pandemicgenerator/GameRepository.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/GameRepository.kt
@@ -1,0 +1,41 @@
+package gabbard.org.pandemicgenerator
+
+import android.content.Context
+import org.gabbard.pandemicgenerator.TrackableState
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.io.Serializable
+import java.util.Random
+
+object GameRepository {
+    private const val FILENAME = "game_session.ser"
+
+    data class GameSession(
+        val trackableState: TrackableState,
+        val rng: Random,
+        val seed: Long
+    ) : Serializable
+
+    fun save(context: Context, session: GameSession) {
+        context.openFileOutput(FILENAME, Context.MODE_PRIVATE).use { fos ->
+            ObjectOutputStream(fos).use { it.writeObject(session) }
+        }
+    }
+
+    fun load(context: Context): GameSession? = try {
+        context.openFileInput(FILENAME).use { fis ->
+            ObjectInputStream(fis).use { ois ->
+                @Suppress("UNCHECKED_CAST")
+                ois.readObject() as GameSession
+            }
+        }
+    } catch (e: Exception) {
+        null
+    }
+
+    fun clear(context: Context) {
+        context.deleteFile(FILENAME)
+    }
+
+    fun exists(context: Context): Boolean = context.fileList().contains(FILENAME)
+}

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
@@ -3,13 +3,12 @@ package gabbard.org.pandemicgenerator
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import gabbard.org.pandemicgenerator.databinding.ActivityInfectionBinding
 import org.gabbard.pandemicgenerator.TrackableState
 import org.gabbard.pandemicgenerator.Transition
 import java.util.*
 
-class InfectionActivity : AppCompatActivity() {
+class InfectionActivity : GameActivity() {
     private lateinit var binding: ActivityInfectionBinding
     private var gameState: TrackableState? = null
     private var rng: Random? = null

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InitialSetup.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InitialSetup.kt
@@ -3,14 +3,13 @@ package gabbard.org.pandemicgenerator
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import gabbard.org.pandemicgenerator.databinding.ActivityInitialSetupBinding
 import org.gabbard.pandemicgenerator.NATIONAL_CHAMPIONSHIP_RULES
 import org.gabbard.pandemicgenerator.TrackableState
 import java.util.*
 
 
-class InitialSetup : AppCompatActivity() {
+class InitialSetup : GameActivity() {
     private lateinit var binding: ActivityInitialSetupBinding
     private var gameState: TrackableState? = null
     private var rng: Random? = null

--- a/app/src/main/java/gabbard/org/pandemicgenerator/MainActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/MainActivity.kt
@@ -4,16 +4,33 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import gabbard.org.pandemicgenerator.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityMainBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        binding.newGame.setOnClickListener {
+            startActivity(Intent(this, EnterRandomSeed::class.java))
+        }
+
+        binding.resumeGame.setOnClickListener {
+            val session = GameRepository.load(this) ?: return@setOnClickListener
+            startActivity(Intent(this, TurnTimer::class.java).apply {
+                putExtra(TurnTimer.GAME_STATE, session.trackableState)
+                putExtra(TurnTimer.RANDOM_SOURCE, session.rng)
+                putExtra(TurnTimer.SEED, session.seed)
+            })
+        }
     }
 
-    fun startGame(@Suppress("UNUSED_PARAMETER") view: View) {
-        val startGameIntent = Intent(this, EnterRandomSeed::class.java)
-        startActivity(startGameIntent)
+    override fun onResume() {
+        super.onResume()
+        binding.resumeGame.visibility =
+            if (GameRepository.exists(this)) View.VISIBLE else View.GONE
     }
 }

--- a/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
@@ -7,13 +7,12 @@ import android.os.Bundle
 import android.os.SystemClock
 import android.view.View
 import android.widget.Chronometer
-import androidx.appcompat.app.AppCompatActivity
 import gabbard.org.pandemicgenerator.databinding.ActivityTurnTimerBinding
 import org.gabbard.pandemicgenerator.TrackableState
 import java.util.*
 
 
-class TurnTimer : AppCompatActivity() {
+class TurnTimer : GameActivity() {
     private lateinit var binding: ActivityTurnTimerBinding
     private var gameState: TrackableState? = null
     private var rng: Random? = null
@@ -35,6 +34,8 @@ class TurnTimer : AppCompatActivity() {
         rng = intent.getSerializableExtra(RANDOM_SOURCE) as Random
         seed = intent.getLongExtra(SEED, 0)
         binding.seedDisplay.text = "Seed: $seed"
+
+        GameRepository.save(this, GameRepository.GameSession(gameState!!, rng!!, seed))
 
         binding.timeRemaining.isCountDown = true
         binding.timeRemaining.start()

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,14 +7,26 @@
     tools:context=".MainActivity">
 
     <Button
-        android:id="@+id/button"
+        android:id="@+id/newGame"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:onClick="startGame"
-        android:text="Start Game"
+        android:text="New Game"
+        app:layout_constraintBottom_toTopOf="@+id/resumeGame"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <Button
+        android:id="@+id/resumeGame"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="Resume Game"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/newGame" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/menu_game.xml
+++ b/app/src/main/res/menu/menu_game.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/action_end_game"
+        android:title="End Game"
+        android:showAsAction="never" />
+</menu>


### PR DESCRIPTION
## Summary

**Persistence**
- `GameRepository` serializes a `GameSession` (TrackableState + rng + seed) to internal app storage using `ObjectOutputStream` — both types are already `Serializable`
- Save point is `TurnTimer.onCreate`, which fires at the start of every turn. Restoring always lands at the timer screen at the beginning of that turn (the draw and infect transitions replay from there, which is deterministic)
- `load()` returns `null` on any exception, so a stale save from an older app version is silently discarded

**Resume Game**
- `MainActivity` now shows a "Resume Game" button alongside "New Game"; the button is shown/hidden in `onResume` so it reflects the current state when returning from a game
- Tapping Resume loads the session and goes directly to `TurnTimer`

**End Game**
- `GameActivity` is a new base class (extends `AppCompatActivity`) that all four in-game screens now extend
- It adds an overflow menu with a single "End Game" item; tapping it shows a confirmation dialog, clears the save file, and navigates back to `MainActivity` clearing the back stack

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ly2HhdYNtAAkr2cgKL7AWa)_