### PR TITLE
Display current player role on TurnTimer activity

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
@@ -34,6 +34,7 @@ class TurnTimer : GameActivity() {
         rng = intent.getSerializableExtra(RANDOM_SOURCE) as Random
         seed = intent.getLongExtra(SEED, 0)
         binding.seedDisplay.text = "Seed: $seed"
+        binding.currentPlayerRole.text = gameState!!.players[gameState!!.curPlayer].role.name
 
         GameRepository.save(this, GameRepository.GameSession(gameState!!, rng!!, seed))
 

--- a/app/src/main/res/layout/activity_turn_timer.xml
+++ b/app/src/main/res/layout/activity_turn_timer.xml
@@ -6,6 +6,18 @@
     android:layout_height="match_parent"
     tools:context=".TurnTimer">
 
+    <TextView
+        android:id="@+id/currentPlayerRole"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="16dp"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <Chronometer
         android:id="@+id/timeRemaining"
         android:layout_width="0dp"
@@ -16,7 +28,7 @@
         app:layout_constraintBottom_toTopOf="@+id/drawPlayerCards"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/currentPlayerRole" />
 
     <Button
         android:id="@+id/drawPlayerCards"


### PR DESCRIPTION
## Summary

- Adds a `TextView` above the countdown timer on the "Take your turn" screen showing the current player's role name
- Role is read from `TrackableState.players[curPlayer].role.name`
- Timer is now constrained below the new role label instead of the top of the parent

Closes #11

## Test plan

- [ ] Start a game and verify the current player's role appears at the top of the TurnTimer screen
- [ ] Advance turns and verify the role updates to reflect the next player

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ly2HhdYNtAAkr2cgKL7AWa)_