### PR TITLE
Fix crash when player deck runs out (closes #14)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,8 @@
         <activity android:name=".EditRuleSetActivity" />
         <activity android:name=".TurnTimer" />
         <activity android:name=".DrawPlayerCards" />
-        <activity android:name=".InfectionActivity"></activity>
+        <activity android:name=".InfectionActivity" />
+        <activity android:name=".GameOverActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
@@ -32,17 +32,24 @@ class DrawPlayerCards : GameActivity() {
         seed = intent.getLongExtra(SEED, 0)
         binding.seedDisplay.text = "Seed: $seed"
 
-        val result = gameState!!.executeTransition(Transition.DRAW_PLAYER_CARDS, rng!!)
-                as TrackableState.TransitionResult.DrawPlayerCardsTransitionResult
-        gameState = result.newGameState
+        when (val result = gameState!!.executeTransition(Transition.DRAW_PLAYER_CARDS, rng!!)) {
+            is TrackableState.TransitionResult.PlayerDeckExhausted -> {
+                startActivity(Intent(this, GameOverActivity::class.java))
+                return
+            }
+            is TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult -> {
+                gameState = result.newGameState
 
-        val container = binding.cardsContainer
-        container.addSectionHeader("Cards drawn:")
-        result.cardsDrawn.forEach { container.addPlayerCardRow(it) }
+                val container = binding.cardsContainer
+                container.addSectionHeader("Cards drawn:")
+                result.cardsDrawn.forEach { container.addPlayerCardRow(it) }
 
-        for ((epidemic, city) in result.epidemicsAndInfectedCities) {
-            container.addSectionHeader("Epidemic: ${epidemic.userString}")
-            container.addCityRow(city, "infected from bottom")
+                for ((epidemic, city) in result.epidemicsAndInfectedCities) {
+                    container.addSectionHeader("Epidemic: ${epidemic.userString}")
+                    container.addCityRow(city, "infected from bottom")
+                }
+            }
+            else -> error("Unexpected result type for DRAW_PLAYER_CARDS: $result")
         }
     }
 

--- a/app/src/main/java/gabbard/org/pandemicgenerator/GameOverActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/GameOverActivity.kt
@@ -1,0 +1,23 @@
+package gabbard.org.pandemicgenerator
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import gabbard.org.pandemicgenerator.databinding.ActivityGameOverBinding
+
+class GameOverActivity : GameActivity() {
+    private lateinit var binding: ActivityGameOverBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityGameOverBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+    }
+
+    fun onReturnToMainMenu(@Suppress("UNUSED_PARAMETER") view: View) {
+        val intent = Intent(this, MainActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+        startActivity(intent)
+        finish()
+    }
+}

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
@@ -33,7 +33,7 @@ class InfectionActivity : GameActivity() {
         binding.seedDisplay.text = "Seed: $seed"
 
         val result = gameState!!.executeTransition(Transition.INFECT, rng!!)
-                as TrackableState.TransitionResult.InfectionTransitionResult
+                as TrackableState.TransitionResult.Success.InfectionTransitionResult
         gameState = result.newGameState
 
         binding.infectedCities.addSectionHeader("Cities infected this turn:")

--- a/app/src/main/res/layout/activity_game_over.xml
+++ b/app/src/main/res/layout/activity_game_over.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="24dp"
+    tools:context=".GameOverActivity">
+
+    <TextView
+        android:id="@+id/gameOverTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="You Lost"
+        android:textSize="48sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/gameOverReason"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <TextView
+        android:id="@+id/gameOverReason"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:gravity="center"
+        android:text="The player deck ran out of cards.\n\nIn Pandemic, players lose if a player cannot draw the required number of player cards."
+        android:textSize="18sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/gameOverTitle"
+        app:layout_constraintBottom_toTopOf="@+id/returnToMainMenu" />
+
+    <Button
+        android:id="@+id/returnToMainMenu"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="48dp"
+        android:layout_marginBottom="48dp"
+        android:text="Return to Main Menu"
+        android:onClick="onReturnToMainMenu"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/gameOverReason" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/GameState.kt
+++ b/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/GameState.kt
@@ -49,20 +49,25 @@ data class TrackableState(val curPlayer: Int,
                 == ALL_CITIES)
     }
 
-    sealed class TransitionResult(open val newGameState: TrackableState) {
+    sealed class TransitionResult {
 
-        data class InfectionTransitionResult(override val newGameState: TrackableState,
-                                             val infectedCities: List<City>)
-            : TransitionResult(newGameState)
+        sealed class Success : TransitionResult() {
+            abstract val newGameState: TrackableState
 
-        data class DrawPlayerCardsTransitionResult(
-                override val newGameState: TrackableState,
-                val cardsDrawn: List<PlayerCard>,
-                val epidemicsAndInfectedCities: List<Pair<Epidemic, City>>) : TransitionResult(newGameState) {
-            init {
-                require(cardsDrawn.containsAll(epidemicsAndInfectedCities.map { it.first }))
+            data class InfectionTransitionResult(override val newGameState: TrackableState,
+                                                 val infectedCities: List<City>) : Success()
+
+            data class DrawPlayerCardsTransitionResult(
+                    override val newGameState: TrackableState,
+                    val cardsDrawn: List<PlayerCard>,
+                    val epidemicsAndInfectedCities: List<Pair<Epidemic, City>>) : Success() {
+                init {
+                    require(cardsDrawn.containsAll(epidemicsAndInfectedCities.map { it.first }))
+                }
             }
         }
+
+        object PlayerDeckExhausted : TransitionResult()
     }
 
 
@@ -70,11 +75,14 @@ data class TrackableState(val curPlayer: Int,
         when (transition) {
             Transition.INFECT -> {
                 val infectionResult = infect()
-                return TransitionResult.InfectionTransitionResult(
+                return TransitionResult.Success.InfectionTransitionResult(
                         infectionResult.newGameState.copy(lastTransition = transition),
                         infectionResult.infectedCities)
             }
             Transition.DRAW_PLAYER_CARDS -> {
+                if (playerDeck.cards.size < 2) {
+                    return TransitionResult.PlayerDeckExhausted
+                }
                 val (cardsDrawn, postDrawState) = drawPlayerCards()
                 var curState = postDrawState
                 val epidemics = cardsDrawn.filterIsInstance<Epidemic>()
@@ -85,7 +93,7 @@ data class TrackableState(val curPlayer: Int,
                     curState = postEpidemicGameState
                     epidemicsToCitiesInfected.add(Pair(epidemic, newCity))
                 }
-                return TransitionResult.DrawPlayerCardsTransitionResult(
+                return TransitionResult.Success.DrawPlayerCardsTransitionResult(
                         curState.copy(lastTransition = transition), cardsDrawn,
                         epidemicsToCitiesInfected)
             }

--- a/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/PandemicGeneratorCli.kt
+++ b/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/PandemicGeneratorCli.kt
@@ -16,9 +16,9 @@ val transitionToCommand = mapOf(Transition.INFECT to "i", Transition.DRAW_PLAYER
 
 fun messageForTransitionResult(result: TrackableState.TransitionResult): String {
     return when (result) {
-        is TrackableState.TransitionResult.InfectionTransitionResult ->
+        is TrackableState.TransitionResult.Success.InfectionTransitionResult ->
             "The following cities were infected: ${result.infectedCities}"
-        is TrackableState.TransitionResult.DrawPlayerCardsTransitionResult -> {
+        is TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult -> {
             val msg = StringBuilder()
             msg.append("Drew: ${result.cardsDrawn}\n\n")
             for ((epidemic, infectedCity) in result.epidemicsAndInfectedCities) {
@@ -26,6 +26,8 @@ fun messageForTransitionResult(result: TrackableState.TransitionResult): String 
             }
             msg.toString()
         }
+        is TrackableState.TransitionResult.PlayerDeckExhausted ->
+            "GAME OVER: The player deck ran out of cards. You lost!"
     }
 }
 fun main(@Suppress("UNUSED_PARAMETER") args: Array<String>) {
@@ -82,8 +84,11 @@ fun main(@Suppress("UNUSED_PARAMETER") args: Array<String>) {
             val transition = commandToTransition[command]
             if (transition != null) {
                 val transitionResult = curState.executeTransition(transition, rng)
-                history.push(transitionResult.newGameState)
                 print("${messageForTransitionResult(transitionResult)}\n")
+                if (transitionResult is TrackableState.TransitionResult.PlayerDeckExhausted) {
+                    break
+                }
+                history.push((transitionResult as TrackableState.TransitionResult.Success).newGameState)
             }
         }
     }

--- a/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/TrackableStateTest.kt
+++ b/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/TrackableStateTest.kt
@@ -48,7 +48,7 @@ class TrackableStateTest {
         val state = makeState(lastTransition = Transition.DRAW_PLAYER_CARDS,
             infectionRate = InfectionRate.INITIAL)
         val result = state.executeTransition(Transition.INFECT, rng)
-                as TrackableState.TransitionResult.InfectionTransitionResult
+                as TrackableState.TransitionResult.Success.InfectionTransitionResult
         assertEquals(InfectionRate.INITIAL.numInfectionCardsToDraw, result.infectedCities.size)
     }
 
@@ -62,7 +62,7 @@ class TrackableStateTest {
             lastTransition = Transition.DRAW_PLAYER_CARDS
         )
         val result = state.executeTransition(Transition.INFECT, rng)
-                as TrackableState.TransitionResult.InfectionTransitionResult
+                as TrackableState.TransitionResult.Success.InfectionTransitionResult
         val newState = result.newGameState
 
         // drawn cities moved from deck to discard
@@ -80,7 +80,7 @@ class TrackableStateTest {
             lastTransition = Transition.DRAW_PLAYER_CARDS
         )
         val result = state.executeTransition(Transition.INFECT, rng)
-                as TrackableState.TransitionResult.InfectionTransitionResult
+                as TrackableState.TransitionResult.Success.InfectionTransitionResult
         val numDrawn = InfectionRate.INITIAL.numInfectionCardsToDraw
         assertEquals(cities.take(numDrawn), result.infectedCities)
     }
@@ -89,6 +89,7 @@ class TrackableStateTest {
     fun infectSetsLastTransition() {
         val state = makeState(lastTransition = Transition.DRAW_PLAYER_CARDS)
         val result = state.executeTransition(Transition.INFECT, rng)
+                as TrackableState.TransitionResult.Success.InfectionTransitionResult
         assertEquals(Transition.INFECT, result.newGameState.lastTransition)
     }
 
@@ -99,7 +100,7 @@ class TrackableStateTest {
         val cityCards = ALL_CITIES.take(5).map { CityPlayerCard(it) }
         val state = makeState(playerCards = cityCards, lastTransition = Transition.INFECT)
         val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
-                as TrackableState.TransitionResult.DrawPlayerCardsTransitionResult
+                as TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult
         assertEquals(2, result.cardsDrawn.size)
         assertEquals(3, result.newGameState.playerDeck.cards.size)
     }
@@ -109,6 +110,7 @@ class TrackableStateTest {
         val cityCards = ALL_CITIES.take(5).map { CityPlayerCard(it) }
         val state = makeState(playerCards = cityCards, lastTransition = Transition.INFECT)
         val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult
         assertEquals(Transition.DRAW_PLAYER_CARDS, result.newGameState.lastTransition)
     }
 
@@ -117,7 +119,7 @@ class TrackableStateTest {
         val cityCards = ALL_CITIES.take(5).map { CityPlayerCard(it) }
         val state = makeState(playerCards = cityCards, lastTransition = Transition.INFECT)
         val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
-                as TrackableState.TransitionResult.DrawPlayerCardsTransitionResult
+                as TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult
         assertTrue(result.epidemicsAndInfectedCities.isEmpty())
     }
 
@@ -133,7 +135,7 @@ class TrackableStateTest {
             lastTransition = Transition.INFECT
         )
         val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
-                as TrackableState.TransitionResult.DrawPlayerCardsTransitionResult
+                as TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult
         assertEquals(InfectionRate.STEP_TWO, result.newGameState.infectionRate)
     }
 
@@ -146,7 +148,7 @@ class TrackableStateTest {
             lastTransition = Transition.INFECT
         )
         val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
-                as TrackableState.TransitionResult.DrawPlayerCardsTransitionResult
+                as TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult
         assertTrue(result.newGameState.infectionDiscardPile.isEmpty())
     }
 
@@ -162,11 +164,38 @@ class TrackableStateTest {
             lastTransition = Transition.INFECT
         )
         val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
-                as TrackableState.TransitionResult.DrawPlayerCardsTransitionResult
+                as TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult
         // bottom of deck = last element
         val expectedCity = infectionCities.last()
         assertEquals(1, result.epidemicsAndInfectedCities.size)
         assertEquals(expectedCity, result.epidemicsAndInfectedCities[0].second)
+    }
+
+    // ── player deck exhaustion ───────────────────────────────────────────────
+
+    @Test
+    fun drawPlayerCardsReturnsExhaustedWhenDeckIsEmpty() {
+        val state = makeState(playerCards = emptyList(), lastTransition = Transition.INFECT)
+        val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+        assertEquals(TrackableState.TransitionResult.PlayerDeckExhausted, result)
+    }
+
+    @Test
+    fun drawPlayerCardsReturnsExhaustedWhenOnlyOneCardRemains() {
+        val state = makeState(
+            playerCards = listOf(CityPlayerCard(ALL_CITIES.first())),
+            lastTransition = Transition.INFECT
+        )
+        val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+        assertEquals(TrackableState.TransitionResult.PlayerDeckExhausted, result)
+    }
+
+    @Test
+    fun drawPlayerCardsSucceedsWhenExactlyTwoCardsRemain() {
+        val cityCards = ALL_CITIES.take(2).map { CityPlayerCard(it) }
+        val state = makeState(playerCards = cityCards, lastTransition = Transition.INFECT)
+        val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+        assertTrue(result is TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult)
     }
 
     @Test
@@ -185,7 +214,7 @@ class TrackableStateTest {
         val preDiscardSize = discardCities.size
 
         val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
-                as TrackableState.TransitionResult.DrawPlayerCardsTransitionResult
+                as TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult
         val newDeck = result.newGameState.infectionDeck
 
         // new deck = old discard (shuffled) + old bottom-card + remaining deck cards


### PR DESCRIPTION
## Summary

- Models player deck exhaustion as a first-class `TransitionResult.PlayerDeckExhausted` variant in the core library instead of throwing `IllegalArgumentException`
- Adds a `GameOverActivity` screen in the Android UI that tells the user they lost and explains why (player deck ran out)
- Updates the CLI to print a game-over message and exit cleanly when exhaustion occurs

## Changes

**Core (`pandemic-generator-core`)**
- `GameState.kt`: Restructured `TransitionResult` sealed hierarchy — success variants now live under `TransitionResult.Success`; new `TransitionResult.PlayerDeckExhausted` object added as a sibling. `executeTransition` returns `PlayerDeckExhausted` when fewer than 2 cards remain in the player deck.
- `PandemicGeneratorCli.kt`: Handles the new result variant (prints message and exits loop).

**Tests**
- Three new tests in `TrackableStateTest`: empty deck → exhausted, 1 card remaining → exhausted, exactly 2 cards → success (boundary case).

**Android UI**
- New `GameOverActivity` + `activity_game_over.xml`: shows "You Lost", explains that the player deck ran out, and offers a "Return to Main Menu" button that clears the back stack.
- `DrawPlayerCards.kt`: Checks the result type — routes to `GameOverActivity` on exhaustion, proceeds normally otherwise.
- `AndroidManifest.xml`: Registers `GameOverActivity`.

## Test plan

- [ ] Run core unit tests: `./gradlew :pandemic-generator-core:test` — all pass including the three new exhaustion tests
- [ ] Build app: `./gradlew assembleDebug`
- [ ] Manually trigger exhaustion: set up a game state with 0 or 1 player cards remaining and tap "Draw Player Cards" — confirm the Game Over screen appears with the correct message
- [ ] Confirm "Return to Main Menu" navigates back to `MainActivity` and clears the back stack

https://claude.ai/code/session_01Ly2HhdYNtAAkr2cgKL7AWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ly2HhdYNtAAkr2cgKL7AWa)_