### PR TITLE
Add game event log to TrackableState

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
         <activity android:name=".DrawPlayerCards" />
         <activity android:name=".InfectionActivity" />
         <activity android:name=".GameOverActivity" />
+        <activity android:name=".GameLogActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
@@ -53,6 +53,9 @@ class DrawPlayerCards : GameActivity() {
         }
     }
 
+    override fun gameStateForLog() = gameState
+    override fun seedForLog() = seed
+
     fun onProceedToInfectionPhase(@Suppress("UNUSED_PARAMETER") view: View) {
         val infectionIntent = Intent(this, InfectionActivity::class.java)
         infectionIntent.putExtra(InfectionActivity.GAME_STATE, gameState!!)

--- a/app/src/main/java/gabbard/org/pandemicgenerator/GameActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/GameActivity.kt
@@ -5,8 +5,12 @@ import android.content.Intent
 import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
+import org.gabbard.pandemicgenerator.TrackableState
 
 abstract class GameActivity : AppCompatActivity() {
+
+    protected open fun gameStateForLog(): TrackableState? = null
+    protected open fun seedForLog(): Long = 0
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.menu_game, menu)
@@ -14,6 +18,16 @@ abstract class GameActivity : AppCompatActivity() {
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {
+        R.id.action_view_log -> {
+            val state = gameStateForLog()
+            if (state != null) {
+                startActivity(Intent(this, GameLogActivity::class.java).apply {
+                    putExtra(GameLogActivity.GAME_STATE, state)
+                    putExtra(GameLogActivity.SEED, seedForLog())
+                })
+            }
+            true
+        }
         R.id.action_end_game -> {
             AlertDialog.Builder(this)
                 .setTitle("End Game")

--- a/app/src/main/java/gabbard/org/pandemicgenerator/GameLogActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/GameLogActivity.kt
@@ -1,0 +1,55 @@
+package gabbard.org.pandemicgenerator
+
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import gabbard.org.pandemicgenerator.databinding.ActivityGameLogBinding
+import org.gabbard.pandemicgenerator.GameEvent
+import org.gabbard.pandemicgenerator.TrackableState
+
+class GameLogActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityGameLogBinding
+
+    companion object {
+        const val GAME_STATE = "game_state"
+        const val SEED = "seed"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityGameLogBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        @Suppress("DEPRECATION")
+        val gameState = intent.getSerializableExtra(GAME_STATE) as TrackableState
+        val seed = intent.getLongExtra(SEED, 0)
+        binding.seedDisplay.text = "Seed: $seed"
+
+        val container = binding.eventLogContainer
+        val log = gameState.eventLog
+        if (log.isEmpty()) {
+            container.addSectionHeader("No events yet")
+        } else {
+            log.forEachIndexed { index, event ->
+                when (event) {
+                    is GameEvent.DrawPlayerCardsEvent -> {
+                        container.addSectionHeader("Event ${index + 1}: Drew Player Cards")
+                        event.cardsDrawn.forEach { container.addPlayerCardRow(it) }
+                        for ((epidemic, city) in event.epidemicsAndInfectedCities) {
+                            container.addSectionHeader("Epidemic: ${epidemic.userString}")
+                            container.addCityRow(city, "infected from bottom")
+                        }
+                    }
+                    is GameEvent.InfectionEvent -> {
+                        container.addSectionHeader("Event ${index + 1}: Infection")
+                        event.infectedCities.forEach { container.addCityRow(it) }
+                    }
+                }
+            }
+        }
+    }
+
+    fun onClose(@Suppress("UNUSED_PARAMETER") view: View) {
+        finish()
+    }
+}

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
@@ -40,6 +40,9 @@ class InfectionActivity : GameActivity() {
         result.infectedCities.forEach { binding.infectedCities.addCityRow(it) }
     }
 
+    override fun gameStateForLog() = gameState
+    override fun seedForLog() = seed
+
     fun onNextTurn(@Suppress("UNUSED_PARAMETER") view: View) {
         val turnTimerIntent = Intent(this, TurnTimer::class.java)
         turnTimerIntent.putExtra(TurnTimer.GAME_STATE, gameState!!)

--- a/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
@@ -68,6 +68,9 @@ class TurnTimer : GameActivity() {
         }
     }
 
+    override fun gameStateForLog() = gameState
+    override fun seedForLog() = seed
+
     fun onDrawPlayerCards(@Suppress("UNUSED_PARAMETER") view: View) {
         val drawPlayerCardsIntent = Intent(this, DrawPlayerCards::class.java)
         drawPlayerCardsIntent.putExtra(DrawPlayerCards.GAME_STATE, gameState!!)

--- a/app/src/main/res/layout/activity_game_log.xml
+++ b/app/src/main/res/layout/activity_game_log.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".GameLogActivity">
+
+    <ScrollView
+        android:id="@+id/scrollView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="32dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/closeButton"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:id="@+id/eventLogContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+
+    </ScrollView>
+
+    <Button
+        android:id="@+id/closeButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="48dp"
+        android:onClick="onClose"
+        android:text="Close"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/seedDisplay"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:alpha="0.5"
+        android:padding="8dp"
+        android:textSize="11sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/menu_game.xml
+++ b/app/src/main/res/menu/menu_game.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
+        android:id="@+id/action_view_log"
+        android:title="View Game Log"
+        android:showAsAction="never" />
+    <item
         android:id="@+id/action_end_game"
         android:title="End Game"
         android:showAsAction="never" />

--- a/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/GameState.kt
+++ b/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/GameState.kt
@@ -32,13 +32,22 @@ data class CityState(val infections: Map<Color, Int>) : Serializable {
 
 data class BoardState(val cityStates: Map<City, CityState>) : Serializable
 
+sealed class GameEvent : Serializable {
+    data class InfectionEvent(val infectedCities: List<City>) : GameEvent()
+    data class DrawPlayerCardsEvent(
+        val cardsDrawn: List<PlayerCard>,
+        val epidemicsAndInfectedCities: List<Pair<Epidemic, City>>
+    ) : GameEvent()
+}
+
 data class TrackableState(val curPlayer: Int,
                           val players: List<Player>,
                           val infectionDeck: Deck<InfectionCard>,
                           val infectionDiscardPile: Set<InfectionCard>,
                           val playerDeck: Deck<PlayerCard>,
                           val infectionRate: InfectionRate,
-                          val lastTransition: Transition) : Serializable {
+                          val lastTransition: Transition,
+                          val eventLog: List<GameEvent> = emptyList()) : Serializable {
     init {
         require(players.size in 2..4)
         require(curPlayer in 0..(players.size - 1))
@@ -75,8 +84,11 @@ data class TrackableState(val curPlayer: Int,
         when (transition) {
             Transition.INFECT -> {
                 val infectionResult = infect()
+                val event = GameEvent.InfectionEvent(infectionResult.infectedCities)
                 return TransitionResult.Success.InfectionTransitionResult(
-                        infectionResult.newGameState.copy(lastTransition = transition),
+                        infectionResult.newGameState.copy(
+                                lastTransition = transition,
+                                eventLog = eventLog + event),
                         infectionResult.infectedCities)
             }
             Transition.DRAW_PLAYER_CARDS -> {
@@ -93,8 +105,12 @@ data class TrackableState(val curPlayer: Int,
                     curState = postEpidemicGameState
                     epidemicsToCitiesInfected.add(Pair(epidemic, newCity))
                 }
+                val event = GameEvent.DrawPlayerCardsEvent(cardsDrawn, epidemicsToCitiesInfected)
                 return TransitionResult.Success.DrawPlayerCardsTransitionResult(
-                        curState.copy(lastTransition = transition), cardsDrawn,
+                        curState.copy(
+                                lastTransition = transition,
+                                eventLog = eventLog + event),
+                        cardsDrawn,
                         epidemicsToCitiesInfected)
             }
         }

--- a/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/PandemicGeneratorCli.kt
+++ b/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/PandemicGeneratorCli.kt
@@ -30,6 +30,17 @@ fun messageForTransitionResult(result: TrackableState.TransitionResult): String 
             "GAME OVER: The player deck ran out of cards. You lost!"
     }
 }
+
+fun messageForGameEvent(event: GameEvent): String = when (event) {
+    is GameEvent.InfectionEvent -> "Infected cities: ${event.infectedCities}"
+    is GameEvent.DrawPlayerCardsEvent -> {
+        val msg = StringBuilder("Drew: ${event.cardsDrawn}")
+        for ((epidemic, infectedCity) in event.epidemicsAndInfectedCities) {
+            msg.append("; $epidemic infects $infectedCity")
+        }
+        msg.toString()
+    }
+}
 fun main(@Suppress("UNUSED_PARAMETER") args: Array<String>) {
     print("Enter random seed: ")
     val rng = Random(readLine()!!.toLong())
@@ -60,7 +71,16 @@ fun main(@Suppress("UNUSED_PARAMETER") args: Array<String>) {
         history.addAll(savedHistory)
     }
 
-    val specialCommands = mapOf("s" to ::save, "l" to ::load)
+    fun showLog() {
+        val log = history.peek().eventLog
+        if (log.isEmpty()) {
+            print("No events yet.\n")
+        } else {
+            log.forEachIndexed { i, event -> print("${i + 1}. ${messageForGameEvent(event)}\n") }
+        }
+    }
+
+    val specialCommands = mapOf("s" to ::save, "l" to ::load, "g" to ::showLog)
 
     history.push(initialState.trackableState)
     transitionToCommand

--- a/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/PandemicGeneratorCli.kt
+++ b/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/PandemicGeneratorCli.kt
@@ -31,16 +31,6 @@ fun messageForTransitionResult(result: TrackableState.TransitionResult): String 
     }
 }
 
-fun messageForGameEvent(event: GameEvent): String = when (event) {
-    is GameEvent.InfectionEvent -> "Infected cities: ${event.infectedCities}"
-    is GameEvent.DrawPlayerCardsEvent -> {
-        val msg = StringBuilder("Drew: ${event.cardsDrawn}")
-        for ((epidemic, infectedCity) in event.epidemicsAndInfectedCities) {
-            msg.append("; $epidemic infects $infectedCity")
-        }
-        msg.toString()
-    }
-}
 fun main(@Suppress("UNUSED_PARAMETER") args: Array<String>) {
     print("Enter random seed: ")
     val rng = Random(readLine()!!.toLong())
@@ -71,16 +61,7 @@ fun main(@Suppress("UNUSED_PARAMETER") args: Array<String>) {
         history.addAll(savedHistory)
     }
 
-    fun showLog() {
-        val log = history.peek().eventLog
-        if (log.isEmpty()) {
-            print("No events yet.\n")
-        } else {
-            log.forEachIndexed { i, event -> print("${i + 1}. ${messageForGameEvent(event)}\n") }
-        }
-    }
-
-    val specialCommands = mapOf("s" to ::save, "l" to ::load, "g" to ::showLog)
+    val specialCommands = mapOf("s" to ::save, "l" to ::load)
 
     history.push(initialState.trackableState)
     transitionToCommand

--- a/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/TrackableStateTest.kt
+++ b/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/TrackableStateTest.kt
@@ -171,6 +171,63 @@ class TrackableStateTest {
         assertEquals(expectedCity, result.epidemicsAndInfectedCities[0].second)
     }
 
+    // ── event log ────────────────────────────────────────────────────────────
+
+    @Test
+    fun infectAppendsInfectionEventToLog() {
+        val state = makeState(lastTransition = Transition.DRAW_PLAYER_CARDS)
+        val result = state.executeTransition(Transition.INFECT, rng)
+                as TrackableState.TransitionResult.Success.InfectionTransitionResult
+        val log = result.newGameState.eventLog
+        assertEquals(1, log.size)
+        val event = log[0] as GameEvent.InfectionEvent
+        assertEquals(result.infectedCities, event.infectedCities)
+    }
+
+    @Test
+    fun drawPlayerCardsAppendsDrawEventToLog() {
+        val cityCards = ALL_CITIES.take(5).map { CityPlayerCard(it) }
+        val state = makeState(playerCards = cityCards, lastTransition = Transition.INFECT)
+        val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult
+        val log = result.newGameState.eventLog
+        assertEquals(1, log.size)
+        val event = log[0] as GameEvent.DrawPlayerCardsEvent
+        assertEquals(result.cardsDrawn, event.cardsDrawn)
+        assertEquals(result.epidemicsAndInfectedCities, event.epidemicsAndInfectedCities)
+    }
+
+    @Test
+    fun epidemicEventRecordsEpidemicCityPair() {
+        val epidemic = NamedEpidemic("Test Epidemic")
+        val cityCards = listOf(epidemic) + ALL_CITIES.take(4).map { CityPlayerCard(it) }
+        val state = makeState(playerCards = cityCards, lastTransition = Transition.INFECT)
+        val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult
+        val event = result.newGameState.eventLog[0] as GameEvent.DrawPlayerCardsEvent
+        assertEquals(1, event.epidemicsAndInfectedCities.size)
+        assertEquals(result.epidemicsAndInfectedCities, event.epidemicsAndInfectedCities)
+    }
+
+    @Test
+    fun eventLogAccumulatesAcrossTransitions() {
+        val cityCards = ALL_CITIES.take(5).map { CityPlayerCard(it) }
+        val state = makeState(playerCards = cityCards, lastTransition = Transition.INFECT)
+        val afterDraw = (state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.Success).newGameState
+        val afterInfect = (afterDraw.executeTransition(Transition.INFECT, rng)
+                as TrackableState.TransitionResult.Success).newGameState
+        assertEquals(2, afterInfect.eventLog.size)
+        assertTrue(afterInfect.eventLog[0] is GameEvent.DrawPlayerCardsEvent)
+        assertTrue(afterInfect.eventLog[1] is GameEvent.InfectionEvent)
+    }
+
+    @Test
+    fun initialStateHasEmptyEventLog() {
+        val state = makeState()
+        assertTrue(state.eventLog.isEmpty())
+    }
+
     // ── player deck exhaustion ───────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Fixes #16.

## Summary

- Adds a `GameEvent` sealed class (`InfectionEvent`, `DrawPlayerCardsEvent`) to `GameState.kt`
- Adds `eventLog: List<GameEvent>` to `TrackableState`; each successful `executeTransition` call appends the appropriate event
- Adds `GameLogActivity` to the Android UI: a scrollable screen showing the full ordered history of draws and infections, using the same colored-dot row style as the rest of the app
- "View Game Log" menu item added to the options menu, accessible from TurnTimer, DrawPlayerCards, and InfectionActivity

## Test plan

- [ ] `./gradlew :pandemic-generator-core:test` — all tests pass
- [ ] `./gradlew assembleDebug` — Android build succeeds
- [ ] Play a few turns, then open the options menu and tap "View Game Log" — confirm all draws and infections are listed in order

https://claude.ai/code/session_01Ly2HhdYNtAAkr2cgKL7AWa