### PR TITLE
Default new custom rulesets to all player counts and standard difficulties

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/EditRuleSetActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/EditRuleSetActivity.kt
@@ -64,10 +64,12 @@ class EditRuleSetActivity : AppCompatActivity() {
         if (existingRuleSet != null) {
             populateFromRuleSet(existingRuleSet, eventCheckBoxes, roleCheckBoxes)
         } else {
-            // Default: add one difficulty row
-            addDifficultyRow(null)
-            // Default: allow 2 players
             binding.playerCount2.isChecked = true
+            binding.playerCount3.isChecked = true
+            binding.playerCount4.isChecked = true
+            for (difficulty in STANDARD_PANDEMIC.availableDifficulties) {
+                addDifficultyRow(difficulty)
+            }
         }
 
         binding.saveButton.setOnClickListener {


### PR DESCRIPTION
Fixes #29.

## Summary

When creating a new custom ruleset, the form now defaults to:
- All player counts checked (2, 3, and 4)
- Standard difficulties pre-populated: Introductory (4 epidemics), Normal (5), Heroic (6) — reusing `STANDARD_PANDEMIC.availableDifficulties` rather than hardcoding

Previously the form defaulted to only 2 players and a single blank difficulty row.

## Test plan

- [ ] `./gradlew :pandemic-generator-core:test assembleDebug` — tests pass, build succeeds
- [ ] Open the app, tap "New Game" → "Create Custom" — confirm all three player count boxes are checked and the three standard difficulties are pre-filled
- [ ] Verify editing an existing custom ruleset is unaffected (still populates from the saved values)

https://claude.ai/code/session_01Ly2HhdYNtAAkr2cgKL7AWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ly2HhdYNtAAkr2cgKL7AWa)_