### PR TITLE
Fix DrawPlayerCards crashing instead of proceeding to InfectionActivity

### DIFF
--- a/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/Card.kt
+++ b/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/Card.kt
@@ -48,7 +48,7 @@ data class Deck<CardType : Card>(val cards: List<CardType>) : Serializable {
     fun shuffled(rng: Random) = Deck(cards.shuffled(rng))
     fun draw(numToDraw: Int): Pair<List<CardType>, Deck<CardType>> {
         require(numToDraw <= cards.size)
-        return Pair(cards.subList(0, numToDraw), Deck(cards.subList(numToDraw, cards.size).toList()))
+        return Pair(cards.subList(0, numToDraw).toList(), Deck(cards.subList(numToDraw, cards.size).toList()))
     }
 
     fun drawOneFromTheBottom(): Pair<CardType, Deck<CardType>> {


### PR DESCRIPTION
## Summary

- `Deck.draw()` was returning `cards.subList(0, n)` — an `ArrayList$SubList` view that is not `Serializable`
- Since commit #37 added the event log, drawn cards are stored in `DrawPlayerCardsEvent.cardsDrawn` inside `gameState.eventLog`
- Serializing `gameState` into the Intent extra for `InfectionActivity` then threw `NotSerializableException`, crashing `DrawPlayerCards` and leaving the user back on `TurnTimer` instead of proceeding to the infection screen
- Fix: call `.toList()` on the drawn-cards subList in `Deck.draw()` to return a proper `ArrayList`

## Test plan

- [ ] Run `./gradlew :pandemic-generator-core:test` — all existing tests pass
- [ ] Start a game and complete a full turn: Draw Player Cards → Proceed to Infection Phase → confirm `InfectionActivity` is shown with infected cities
- [ ] Verify subsequent turns also navigate correctly through the full cycle

https://claude.ai/code/session_01Ly2HhdYNtAAkr2cgKL7AWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ly2HhdYNtAAkr2cgKL7AWa)_