### PR TITLE
Add targeted tests for card types, city state, UI screens, and repository serialization

### DIFF
--- a/app/src/test/java/gabbard/org/pandemicgenerator/EnterRandomSeedTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/EnterRandomSeedTest.kt
@@ -1,0 +1,107 @@
+package gabbard.org.pandemicgenerator
+
+import android.content.Intent
+import android.widget.EditText
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import org.gabbard.pandemicgenerator.NATIONAL_CHAMPIONSHIP_RULES
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class EnterRandomSeedTest {
+
+    private fun intent(): Intent =
+        Intent(ApplicationProvider.getApplicationContext(), EnterRandomSeed::class.java).apply {
+            putExtra(EnterRandomSeed.GAME_RULES, NATIONAL_CHAMPIONSHIP_RULES)
+        }
+
+    // ── random seed button ────────────────────────────────────────────────────
+
+    @Test
+    fun randomSeedButtonFillsSeedField() {
+        ActivityScenario.launch<EnterRandomSeed>(intent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<android.view.View>(R.id.randomSeedButton).performClick()
+                val text = activity.findViewById<EditText>(R.id.startGame).text.toString()
+                assertFalse("seed field should not be empty after clicking Random Seed", text.isEmpty())
+            }
+        }
+    }
+
+    @Test
+    fun randomSeedIsInValidRange() {
+        ActivityScenario.launch<EnterRandomSeed>(intent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<android.view.View>(R.id.randomSeedButton).performClick()
+                val seed = activity.findViewById<EditText>(R.id.startGame).text.toString().toLong()
+                assertTrue("seed should be non-negative", seed >= 0L)
+                assertTrue("seed should be < 1_000_000", seed < 1_000_000L)
+            }
+        }
+    }
+
+    @Test
+    fun repeatedClicksProduceDifferentSeeds() {
+        ActivityScenario.launch<EnterRandomSeed>(intent()).use { scenario ->
+            val seeds = mutableSetOf<String>()
+            scenario.onActivity { activity ->
+                val btn = activity.findViewById<android.view.View>(R.id.randomSeedButton)
+                val field = activity.findViewById<EditText>(R.id.startGame)
+                repeat(10) {
+                    btn.performClick()
+                    seeds.add(field.text.toString())
+                }
+            }
+            // With 10 clicks over a 0..999999 range, virtually guaranteed to get >1 distinct value
+            assertTrue("repeated clicks should produce varied seeds", seeds.size > 1)
+        }
+    }
+
+    // ── start game navigation ─────────────────────────────────────────────────
+
+    @Test
+    fun startGameNavigatesToInitialSetup() {
+        ActivityScenario.launch<EnterRandomSeed>(intent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<EditText>(R.id.startGame).setText("12345")
+                activity.findViewById<android.view.View>(R.id.button2).performClick()
+                val started = shadowOf(activity).nextStartedActivity
+                assertEquals(InitialSetup::class.java.name, started.component?.className)
+            }
+        }
+    }
+
+    @Test
+    fun startGamePassesCorrectSeedToInitialSetup() {
+        ActivityScenario.launch<EnterRandomSeed>(intent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<EditText>(R.id.startGame).setText("99999")
+                activity.findViewById<android.view.View>(R.id.button2).performClick()
+                val started = shadowOf(activity).nextStartedActivity
+                assertEquals(99999L, started.getLongExtra(InitialSetup.SEED, -1L))
+            }
+        }
+    }
+
+    @Test
+    fun startGamePassesGameRulesToInitialSetup() {
+        ActivityScenario.launch<EnterRandomSeed>(intent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<EditText>(R.id.startGame).setText("42")
+                activity.findViewById<android.view.View>(R.id.button2).performClick()
+                val started = shadowOf(activity).nextStartedActivity
+                @Suppress("DEPRECATION")
+                val rules = started.getSerializableExtra(InitialSetup.GAME_RULES)
+                assertEquals(NATIONAL_CHAMPIONSHIP_RULES, rules)
+            }
+        }
+    }
+}

--- a/app/src/test/java/gabbard/org/pandemicgenerator/GameLogActivityTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/GameLogActivityTest.kt
@@ -1,0 +1,175 @@
+package gabbard.org.pandemicgenerator
+
+import android.content.Intent
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import org.gabbard.pandemicgenerator.ALL_CITIES
+import org.gabbard.pandemicgenerator.CityPlayerCard
+import org.gabbard.pandemicgenerator.Deck
+import org.gabbard.pandemicgenerator.Epidemic
+import org.gabbard.pandemicgenerator.GameEvent
+import org.gabbard.pandemicgenerator.InfectionCard
+import org.gabbard.pandemicgenerator.InfectionRate
+import org.gabbard.pandemicgenerator.NamedEpidemic
+import org.gabbard.pandemicgenerator.Player
+import org.gabbard.pandemicgenerator.PlayerCard
+import org.gabbard.pandemicgenerator.Role
+import org.gabbard.pandemicgenerator.TrackableState
+import org.gabbard.pandemicgenerator.Transition
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.Random
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class GameLogActivityTest {
+
+    private val cities = ALL_CITIES.toList()
+    private val rng = Random(42)
+
+    // ── empty log ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun emptyLogShowsNoEventsHeader() {
+        val state = makeState()
+        ActivityScenario.launch<GameLogActivity>(intentFor(state)).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = activity.findViewById<LinearLayout>(R.id.eventLogContainer)
+                // addSectionHeader adds one TextView child
+                assertEquals(1, container.childCount)
+                val header = container.getChildAt(0) as TextView
+                assertTrue(header.text.contains("No events yet"))
+            }
+        }
+    }
+
+    @Test
+    fun seedIsDisplayedInFooter() {
+        val state = makeState()
+        ActivityScenario.launch<GameLogActivity>(intentFor(state, seed = 99L)).use { scenario ->
+            scenario.onActivity { activity ->
+                val seedView = activity.findViewById<TextView>(R.id.seedDisplay)
+                assertTrue(seedView.text.contains("99"))
+            }
+        }
+    }
+
+    // ── DrawPlayerCards event ─────────────────────────────────────────────────
+
+    @Test
+    fun drawPlayerCardsEventAppearsInLog() {
+        val state = stateAfterDraw()
+        ActivityScenario.launch<GameLogActivity>(intentFor(state)).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = activity.findViewById<LinearLayout>(R.id.eventLogContainer)
+                // At least the section header was added
+                assertTrue(container.childCount > 0)
+                val header = container.getChildAt(0) as TextView
+                assertTrue(header.text.contains("Drew Player Cards"))
+            }
+        }
+    }
+
+    @Test
+    fun drawEventIsNumberedCorrectly() {
+        val state = stateAfterDraw()
+        ActivityScenario.launch<GameLogActivity>(intentFor(state)).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = activity.findViewById<LinearLayout>(R.id.eventLogContainer)
+                val header = container.getChildAt(0) as TextView
+                assertTrue("Header should say Event 1", header.text.contains("Event 1"))
+            }
+        }
+    }
+
+    // ── InfectionEvent ────────────────────────────────────────────────────────
+
+    @Test
+    fun infectionEventAppearsInLog() {
+        val state = stateAfterInfect()
+        ActivityScenario.launch<GameLogActivity>(intentFor(state)).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = activity.findViewById<LinearLayout>(R.id.eventLogContainer)
+                assertTrue(container.childCount > 0)
+                val header = container.getChildAt(0) as TextView
+                assertTrue(header.text.contains("Infection"))
+            }
+        }
+    }
+
+    @Test
+    fun multipleEventsAreNumberedSequentially() {
+        val afterDraw = stateAfterDraw()
+        val afterInfect = stateAfterInfect(afterDraw)
+        assertEquals(2, afterInfect.eventLog.size)
+
+        ActivityScenario.launch<GameLogActivity>(intentFor(afterInfect)).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = activity.findViewById<LinearLayout>(R.id.eventLogContainer)
+                val headers = (0 until container.childCount)
+                    .map { container.getChildAt(it) }
+                    .filterIsInstance<TextView>()
+                    .map { it.text.toString() }
+                assertTrue(headers.any { it.contains("Event 1") })
+                assertTrue(headers.any { it.contains("Event 2") })
+            }
+        }
+    }
+
+    // ── close button ──────────────────────────────────────────────────────────
+
+    @Test
+    fun closeButtonFinishesActivity() {
+        ActivityScenario.launch<GameLogActivity>(intentFor(makeState())).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<android.view.View>(R.id.closeButton).performClick()
+                assertTrue("activity should be finishing after close", activity.isFinishing)
+            }
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun intentFor(state: TrackableState, seed: Long = 42L): Intent =
+        Intent(ApplicationProvider.getApplicationContext(), GameLogActivity::class.java).apply {
+            putExtra(GameLogActivity.GAME_STATE, state)
+            putExtra(GameLogActivity.SEED, seed)
+        }
+
+    private fun makeState(
+        playerCards: List<PlayerCard> = cities.take(5).map { CityPlayerCard(it) },
+        lastTransition: Transition = Transition.INFECT,
+        eventLog: List<GameEvent> = emptyList()
+    ): TrackableState {
+        val players = listOf(Player(Role("Medic")), Player(Role("Scientist")))
+        return TrackableState(
+            curPlayer = 0,
+            players = players,
+            infectionDeck = Deck(cities.take(10).map { InfectionCard(it) }),
+            infectionDiscardPile = cities.drop(10).map { InfectionCard(it) }.toSet(),
+            playerDeck = Deck(playerCards),
+            infectionRate = InfectionRate.INITIAL,
+            lastTransition = lastTransition,
+            eventLog = eventLog
+        )
+    }
+
+    private fun stateAfterDraw(): TrackableState {
+        val state = makeState(lastTransition = Transition.INFECT)
+        return (state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult)
+            .newGameState
+    }
+
+    private fun stateAfterInfect(base: TrackableState = makeState(lastTransition = Transition.DRAW_PLAYER_CARDS)): TrackableState {
+        return (base.executeTransition(Transition.INFECT, rng)
+                as TrackableState.TransitionResult.Success.InfectionTransitionResult)
+            .newGameState
+    }
+}

--- a/app/src/test/java/gabbard/org/pandemicgenerator/NavigationTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/NavigationTest.kt
@@ -23,6 +23,8 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import org.robolectric.fakes.RoboMenuItem
+import org.robolectric.shadows.ShadowAlertDialog
 import java.util.Random
 
 /**
@@ -210,6 +212,70 @@ class NavigationTest {
             putExtra(TurnTimer.SEED, 42L)
             putExtra(TurnTimer.TURN_DURATION, TurnTimer.NO_TIMER)
         }
+
+    // ── MainActivity resume-game click ────────────────────────────────────────
+
+    @Test
+    fun resumeGameClickNavigatesToTurnTimer() {
+        GameRepository.save(context, makeGameSession())
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<View>(R.id.resumeGame).performClick()
+                val started = shadowOf(activity).nextStartedActivity
+                assertEquals(TurnTimer::class.java.name, started.component?.className)
+            }
+        }
+    }
+
+    @Test
+    fun resumeGameClickPassesSavedStateToTurnTimer() {
+        val session = makeGameSession()
+        GameRepository.save(context, session)
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<View>(R.id.resumeGame).performClick()
+                val started = shadowOf(activity).nextStartedActivity
+                @Suppress("DEPRECATION")
+                val passedState = started.getSerializableExtra(TurnTimer.GAME_STATE) as TrackableState
+                assertEquals(session.trackableState, passedState)
+            }
+        }
+    }
+
+    // ── GameActivity options menu ──────────────────────────────────────────────
+
+    @Test
+    fun viewLogMenuItemStartsGameLogActivity() {
+        ActivityScenario.launch<TurnTimer>(turnTimerIntent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.onOptionsItemSelected(RoboMenuItem(R.id.action_view_log))
+                val started = shadowOf(activity).nextStartedActivity
+                assertEquals(GameLogActivity::class.java.name, started.component?.className)
+            }
+        }
+    }
+
+    @Test
+    fun viewLogMenuItemPassesCurrentStateToGameLogActivity() {
+        ActivityScenario.launch<TurnTimer>(turnTimerIntent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.onOptionsItemSelected(RoboMenuItem(R.id.action_view_log))
+                val started = shadowOf(activity).nextStartedActivity
+                @Suppress("DEPRECATION")
+                assertNotNull(started.getSerializableExtra(GameLogActivity.GAME_STATE))
+            }
+        }
+    }
+
+    @Test
+    fun endGameMenuItemShowsConfirmationDialog() {
+        ActivityScenario.launch<TurnTimer>(turnTimerIntent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.onOptionsItemSelected(RoboMenuItem(R.id.action_end_game))
+                assertNotNull("End Game dialog should appear", ShadowAlertDialog.getLatestAlertDialog())
+            }
+        }
+    }
 
     private fun makeGameSession(): GameRepository.GameSession =
         GameRepository.GameSession(

--- a/app/src/test/java/gabbard/org/pandemicgenerator/RuleSetRepositoryTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/RuleSetRepositoryTest.kt
@@ -1,0 +1,84 @@
+package gabbard.org.pandemicgenerator
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.gabbard.pandemicgenerator.NATIONAL_CHAMPIONSHIP
+import org.gabbard.pandemicgenerator.RuleSet
+import org.gabbard.pandemicgenerator.STANDARD_PANDEMIC
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class RuleSetRepositoryTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @After
+    fun tearDown() {
+        // Remove the file so tests are isolated
+        context.deleteFile("custom_rule_sets.ser")
+    }
+
+    // ── load ──────────────────────────────────────────────────────────────────
+
+    @Test
+    fun loadReturnsEmptyListWhenNoFileSaved() {
+        assertTrue(RuleSetRepository.load(context).isEmpty())
+    }
+
+    @Test
+    fun loadReturnsEmptyListAfterCorruptedWrite() {
+        // Write garbage bytes to the file so deserialization fails
+        context.openFileOutput("custom_rule_sets.ser", Context.MODE_PRIVATE)
+            .use { it.write(byteArrayOf(0, 1, 2, 3)) }
+        assertTrue("corrupted file should return empty list", RuleSetRepository.load(context).isEmpty())
+    }
+
+    // ── save / load round-trip ────────────────────────────────────────────────
+
+    @Test
+    fun saveAndLoadRoundTripsEmptyList() {
+        RuleSetRepository.save(context, emptyList())
+        assertTrue(RuleSetRepository.load(context).isEmpty())
+    }
+
+    @Test
+    fun saveAndLoadRoundTripsSingleRuleSet() {
+        RuleSetRepository.save(context, listOf(NATIONAL_CHAMPIONSHIP))
+        val loaded = RuleSetRepository.load(context)
+        assertEquals(1, loaded.size)
+        assertEquals(NATIONAL_CHAMPIONSHIP, loaded[0])
+    }
+
+    @Test
+    fun saveAndLoadRoundTripsMultipleRuleSets() {
+        val ruleSets = listOf(NATIONAL_CHAMPIONSHIP, NATIONAL_CHAMPIONSHIP)
+        RuleSetRepository.save(context, ruleSets)
+        val loaded = RuleSetRepository.load(context)
+        assertEquals(2, loaded.size)
+        assertEquals(NATIONAL_CHAMPIONSHIP, loaded[0])
+        assertEquals(NATIONAL_CHAMPIONSHIP, loaded[1])
+    }
+
+    @Test
+    fun secondSaveOverwritesFirst() {
+        RuleSetRepository.save(context, listOf(STANDARD_PANDEMIC))
+        RuleSetRepository.save(context, listOf(NATIONAL_CHAMPIONSHIP))
+        val loaded = RuleSetRepository.load(context)
+        assertEquals(1, loaded.size)
+        assertEquals(NATIONAL_CHAMPIONSHIP, loaded[0])
+    }
+
+    @Test
+    fun ruleSetNamesArePreservedAfterRoundTrip() {
+        RuleSetRepository.save(context, listOf(STANDARD_PANDEMIC, NATIONAL_CHAMPIONSHIP))
+        val names = RuleSetRepository.load(context).map(RuleSet::name)
+        assertEquals(listOf("Standard Pandemic", "National Championship"), names)
+    }
+}

--- a/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/CardTest.kt
+++ b/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/CardTest.kt
@@ -1,0 +1,69 @@
+package org.gabbard.pandemicgenerator
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CardTest {
+
+    private val city = City("London", Color.BLUE)
+
+    // ── CityPlayerCard ────────────────────────────────────────────────────────
+
+    @Test
+    fun cityPlayerCardUserStringReturnsCityName() {
+        assertEquals("London", CityPlayerCard(city).userString)
+    }
+
+    @Test
+    fun cityPlayerCardToStringReturnsCityName() {
+        assertEquals("London", CityPlayerCard(city).toString())
+    }
+
+    // ── InfectionCard ─────────────────────────────────────────────────────────
+
+    @Test
+    fun infectionCardUserStringReturnsCityName() {
+        assertEquals("London", InfectionCard(city).userString)
+    }
+
+    @Test
+    fun infectionCardToStringReturnsCityName() {
+        assertEquals("London", InfectionCard(city).toString())
+    }
+
+    // ── SimpleEpidemic ────────────────────────────────────────────────────────
+
+    @Test
+    fun simpleEpidemicUserStringIsEpidemic() {
+        assertEquals("Epidemic", SimpleEpidemic().userString)
+    }
+
+    @Test
+    fun simpleEpidemicToStringIsEpidemic() {
+        assertEquals("Epidemic", SimpleEpidemic().toString())
+    }
+
+    // ── NamedEpidemic ─────────────────────────────────────────────────────────
+
+    @Test
+    fun namedEpidemicUserStringReturnsName() {
+        assertEquals("Slippery Slope", NamedEpidemic("Slippery Slope").userString)
+    }
+
+    @Test
+    fun namedEpidemicToStringReturnsName() {
+        assertEquals("Slippery Slope", NamedEpidemic("Slippery Slope").toString())
+    }
+
+    // ── EventCard ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun eventCardUserStringReturnsName() {
+        assertEquals("Airlift", EventCard("Airlift").userString)
+    }
+
+    @Test
+    fun eventCardToStringReturnsName() {
+        assertEquals("Airlift", EventCard("Airlift").toString())
+    }
+}

--- a/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/CityStateTest.kt
+++ b/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/CityStateTest.kt
@@ -1,0 +1,54 @@
+package org.gabbard.pandemicgenerator
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CityStateTest {
+
+    // ── valid construction ────────────────────────────────────────────────────
+
+    @Test
+    fun emptyInfectionsIsValid() {
+        CityState(emptyMap()) // must not throw
+    }
+
+    @Test
+    fun zeroCubesIsValid() {
+        CityState(mapOf(Color.BLUE to 0))
+    }
+
+    @Test
+    fun threeCubesIsValid() {
+        CityState(mapOf(Color.BLUE to 3))
+    }
+
+    @Test
+    fun multipleColorsAtMaxIsValid() {
+        CityState(mapOf(Color.BLUE to 3, Color.RED to 3))
+    }
+
+    // ── invalid construction ──────────────────────────────────────────────────
+
+    @Test(expected = IllegalArgumentException::class)
+    fun fourCubesThrows() {
+        CityState(mapOf(Color.BLUE to 4))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun negativeCubesThrows() {
+        CityState(mapOf(Color.BLUE to -1))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun oneColorValidOneColorInvalidThrows() {
+        CityState(mapOf(Color.BLUE to 2, Color.RED to 5))
+    }
+
+    // ── toString ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun toStringDelegatesToInfectionsMap() {
+        val infections = mapOf(Color.BLUE to 2)
+        assertEquals(infections.toString(), CityState(infections).toString())
+    }
+}


### PR DESCRIPTION
## Summary

- **`CardTest`** — covers `userString`/`toString` for all card subtypes (`CityPlayerCard`, `InfectionCard`, `SimpleEpidemic`, `NamedEpidemic`, `EventCard`)
- **`CityStateTest`** — construction validation (0–3 cubes valid, 4/negative throws) and `toString` delegation
- **`EnterRandomSeedTest`** — random seed generation, valid range (0–999,999), uniqueness across clicks, and navigation to `InitialSetup` with correct seed and rules
- **`GameLogActivityTest`** — empty log header, draw/infection events appear with correct numbering, close button finishes activity
- **`RuleSetRepositoryTest`** — load on missing file, corrupted file recovery, save/load round-trips, second save overwrites first, names preserved after round-trip
- **`NavigationTest` extensions** — resume-game flow, view-log menu item, end-game confirmation dialog

## Test plan

- [ ] All 164 tests pass locally (`./gradlew :app:testDebugUnitTest :pandemic-generator-core:test`)
- [ ] CI green

https://claude.ai/code/session_01Ly2HhdYNtAAkr2cgKL7AWa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ly2HhdYNtAAkr2cgKL7AWa)_