### PR TITLE
Exclude Troubleshooter role; add note on ruleset editing screen

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/EditRuleSetActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/EditRuleSetActivity.kt
@@ -49,8 +49,8 @@ class EditRuleSetActivity : AppCompatActivity() {
             eventCheckBoxes[event] = cb
         }
 
-        // Pre-populate role checkboxes from ALL_ROLES
-        val sortedRoles = ALL_ROLES.sortedBy { it.name }
+        // Pre-populate role checkboxes, excluding roles unsupported in multi-board games
+        val sortedRoles = MULTI_BOARD_COMPATIBLE_ROLES.sortedBy { it.name }
         val roleCheckBoxes = mutableMapOf<Role, CheckBox>()
         for (role in sortedRoles) {
             val cb = CheckBox(this).apply { text = role.name }

--- a/app/src/main/res/layout/activity_edit_ruleset.xml
+++ b/app/src/main/res/layout/activity_edit_ruleset.xml
@@ -179,7 +179,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Note: The Troubleshooter is not listed because it requires viewing the top infection cards, which is not supported in multi-board games."
+            android:text="Note: The Troubleshooter is not listed because it requires viewing the top infection cards, which is not yet implemented."
             android:textStyle="italic"
             android:textSize="13sp"
             android:layout_marginTop="4dp"

--- a/app/src/main/res/layout/activity_edit_ruleset.xml
+++ b/app/src/main/res/layout/activity_edit_ruleset.xml
@@ -174,7 +174,15 @@
             android:id="@+id/roles_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
+            android:orientation="vertical" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Note: The Troubleshooter is not listed because it requires viewing the top infection cards, which is not supported in multi-board games."
+            android:textStyle="italic"
+            android:textSize="13sp"
+            android:layout_marginTop="4dp"
             android:layout_marginBottom="16dp" />
 
         <Button

--- a/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/Role.kt
+++ b/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/Role.kt
@@ -12,6 +12,9 @@ val SECOND_EDITION_ROLES = setOf("Contingency Planner", "Quarantine Specialist")
         .map { Role(it) }.toSet()
 val ON_THE_BRINK_ROLES = setOf("Containment Specialist", "Field Operative", "Archivist",
         "Generalist", "Epidemiologist").map { Role(it) }.toSet()
+// Troubleshooter requires viewing the top N infection cards, which is not supported in multi-board games.
+val IN_THE_LAB_ROLES = setOf("Troubleshooter").map { Role(it) }.toSet()
 val COMPETITIVE_PLAY_ROLES = BASE_ROLES.union(ON_THE_BRINK_ROLES).union(SECOND_EDITION_ROLES)
         .toSet()
-val ALL_ROLES = BASE_ROLES.union(SECOND_EDITION_ROLES).union(ON_THE_BRINK_ROLES)
+val ALL_ROLES = BASE_ROLES.union(SECOND_EDITION_ROLES).union(ON_THE_BRINK_ROLES).union(IN_THE_LAB_ROLES)
+val MULTI_BOARD_COMPATIBLE_ROLES: Set<Role> = ALL_ROLES - IN_THE_LAB_ROLES

--- a/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/Role.kt
+++ b/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/Role.kt
@@ -12,9 +12,9 @@ val SECOND_EDITION_ROLES = setOf("Contingency Planner", "Quarantine Specialist")
         .map { Role(it) }.toSet()
 val ON_THE_BRINK_ROLES = setOf("Containment Specialist", "Field Operative", "Archivist",
         "Generalist", "Epidemiologist").map { Role(it) }.toSet()
-// Troubleshooter requires viewing the top N infection cards, which is not supported in multi-board games.
-val IN_THE_LAB_ROLES = setOf("Troubleshooter").map { Role(it) }.toSet()
 val COMPETITIVE_PLAY_ROLES = BASE_ROLES.union(ON_THE_BRINK_ROLES).union(SECOND_EDITION_ROLES)
         .toSet()
-val ALL_ROLES = BASE_ROLES.union(SECOND_EDITION_ROLES).union(ON_THE_BRINK_ROLES).union(IN_THE_LAB_ROLES)
-val MULTI_BOARD_COMPATIBLE_ROLES: Set<Role> = ALL_ROLES - IN_THE_LAB_ROLES
+// Troubleshooter requires viewing the top N infection cards, which is not yet implemented.
+val INFECTION_DECK_INTERACTION_ROLES: Set<Role> = setOf(Role("Troubleshooter"))
+val ALL_ROLES = BASE_ROLES.union(SECOND_EDITION_ROLES).union(ON_THE_BRINK_ROLES).union(INFECTION_DECK_INTERACTION_ROLES)
+val MULTI_BOARD_COMPATIBLE_ROLES: Set<Role> = ALL_ROLES - INFECTION_DECK_INTERACTION_ROLES


### PR DESCRIPTION
The Troubleshooter (In the Lab expansion) requires viewing the top N infection cards, which is not yet implemented. Adds it to `INFECTION_DECK_INTERACTION_ROLES` (mirroring `INFECTION_DECK_INTERACTION_EVENTS`), derives `MULTI_BOARD_COMPATIBLE_ROLES` excluding it, uses that set in the custom ruleset editor, and adds an explanatory note in the UI.

Closes #40.

https://claude.ai/code/session_01Uypn2zjkNDA7zAajAbsFxJ