### PR TITLE
Fix turn order never advancing

### DIFF
--- a/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/GameState.kt
+++ b/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/GameState.kt
@@ -87,6 +87,7 @@ data class TrackableState(val curPlayer: Int,
                 val event = GameEvent.InfectionEvent(infectionResult.infectedCities)
                 return TransitionResult.Success.InfectionTransitionResult(
                         infectionResult.newGameState.copy(
+                                curPlayer = (curPlayer + 1) % players.size,
                                 lastTransition = transition,
                                 eventLog = eventLog + event),
                         infectionResult.infectedCities)

--- a/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/RuleSetTest.kt
+++ b/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/RuleSetTest.kt
@@ -178,6 +178,34 @@ class RuleSetTest {
         assertTrue(BUILT_IN_RULE_SETS.contains(NATIONAL_CHAMPIONSHIP))
     }
 
+    // ── turn order across a full game (regression test for #55) ─────────────
+
+    @Test
+    fun curPlayerAlternatesCorrectlyAcrossTurnsIncludingAnEpidemic() {
+        val rng = Random(713)
+        var state = NATIONAL_CHAMPIONSHIP_RULES.setupGame(rng).trackableState
+        var sawEpidemic = false
+
+        repeat(6) { turn ->
+            assertEquals("wrong current player before turn $turn", turn % 2, state.curPlayer)
+
+            val drawResult = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                    as TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult
+            if (drawResult.epidemicsAndInfectedCities.isNotEmpty()) {
+                sawEpidemic = true
+            }
+            state = drawResult.newGameState
+            // still the same player's turn until they finish infecting
+            assertEquals("curPlayer changed during draw on turn $turn", turn % 2, state.curPlayer)
+
+            state = (state.executeTransition(Transition.INFECT, rng)
+                    as TrackableState.TransitionResult.Success).newGameState
+            assertEquals("curPlayer did not advance after turn $turn", (turn + 1) % 2, state.curPlayer)
+        }
+
+        assertTrue("test seed should have produced an epidemic to exercise the regression", sawEpidemic)
+    }
+
     // ── chooseDistinct ────────────────────────────────────────────────────────
 
     @Test

--- a/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/TrackableStateTest.kt
+++ b/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/TrackableStateTest.kt
@@ -255,6 +255,60 @@ class TrackableStateTest {
         assertTrue(result is TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult)
     }
 
+    // ── turn order (curPlayer) ───────────────────────────────────────────────
+
+    @Test
+    fun drawPlayerCardsDoesNotAdvanceCurPlayer() {
+        val cityCards = ALL_CITIES.take(5).map { CityPlayerCard(it) }
+        val state = makeState(playerCards = cityCards, lastTransition = Transition.INFECT)
+        val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult
+        assertEquals(0, result.newGameState.curPlayer)
+    }
+
+    @Test
+    fun infectAdvancesCurPlayerToNextPlayer() {
+        val state = makeState(lastTransition = Transition.DRAW_PLAYER_CARDS)
+        val result = state.executeTransition(Transition.INFECT, rng)
+                as TrackableState.TransitionResult.Success.InfectionTransitionResult
+        assertEquals(1, result.newGameState.curPlayer)
+    }
+
+    @Test
+    fun infectWrapsCurPlayerAroundToFirstPlayer() {
+        val cityCards = ALL_CITIES.take(5).map { CityPlayerCard(it) }
+        val state = makeState(playerCards = cityCards, lastTransition = Transition.INFECT)
+        val afterDraw = (state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.Success).newGameState
+        assertEquals(0, afterDraw.curPlayer)
+        val afterInfect = (afterDraw.executeTransition(Transition.INFECT, rng)
+                as TrackableState.TransitionResult.Success).newGameState
+        assertEquals(1, afterInfect.curPlayer)
+
+        val afterDraw2 = (afterInfect.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.Success).newGameState
+        assertEquals(1, afterDraw2.curPlayer)
+        val afterInfect2 = (afterDraw2.executeTransition(Transition.INFECT, rng)
+                as TrackableState.TransitionResult.Success).newGameState
+        assertEquals(0, afterInfect2.curPlayer)
+    }
+
+    @Test
+    fun curPlayerKeepsAlternatingAcrossAnEpidemic() {
+        // Regression test for #55: turn order was lost after an epidemic was drawn.
+        val epidemic = NamedEpidemic("Test Epidemic")
+        val cityCards = listOf(epidemic) + ALL_CITIES.take(4).map { CityPlayerCard(it) }
+        var state = makeState(playerCards = cityCards, lastTransition = Transition.INFECT)
+
+        // Turn 1 (player 0): draw (triggers the epidemic), then infect.
+        state = (state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.Success).newGameState
+        assertEquals(0, state.curPlayer)
+        state = (state.executeTransition(Transition.INFECT, rng)
+                as TrackableState.TransitionResult.Success).newGameState
+        assertEquals(1, state.curPlayer)
+    }
+
     @Test
     fun epidemicShufflesDiscardOntoTopOfDeck() {
         val epidemic = NamedEpidemic("Test Epidemic")


### PR DESCRIPTION
## Summary
- `TrackableState.curPlayer` was initialized at game setup but never advanced by `executeTransition` — the app always displayed the first player as the current player for the entire game (not just after an epidemic, as originally reported in #55).
- Advance `curPlayer` (mod number of players) when the `INFECT` transition completes, since infection is the last step of a turn before the next player's `DRAW_PLAYER_CARDS`.

## Test plan
- [x] Reproduced the bug with a unit test simulating `NATIONAL_CHAMPIONSHIP_RULES.setupGame(Random(713))` (the exact seed from #55) and confirmed `curPlayer` stayed `0` for the whole game, even before the epidemic.
- [x] Added `TrackableStateTest` cases verifying `curPlayer` stays put during `DRAW_PLAYER_CARDS` and correctly advances/wraps on `INFECT`.
- [x] Added a `RuleSetTest` full-game simulation (seed 713) asserting `curPlayer` alternates correctly across 6 turns, including one that draws an epidemic.
- [x] `./gradlew :pandemic-generator-core:test` passes.

Closes #55.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KH3RPuWHg3dbWTZds4exY3


---
_Generated by [Claude Code](https://claude.ai/code/session_01KH3RPuWHg3dbWTZds4exY3)_