### PR TITLE
Pin current player indicator to Draw Cards and Infection screens

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
@@ -31,6 +31,7 @@ class DrawPlayerCards : GameActivity() {
         rng = intent.getSerializableExtra(DrawPlayerCards.RANDOM_SOURCE) as Random
         seed = intent.getLongExtra(SEED, 0)
         binding.seedDisplay.text = "Seed: $seed"
+        binding.currentPlayerRole.text = gameState!!.players[gameState!!.curPlayer].role.name
 
         when (val result = gameState!!.executeTransition(Transition.DRAW_PLAYER_CARDS, rng!!)) {
             is TrackableState.TransitionResult.PlayerDeckExhausted -> {

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
@@ -31,6 +31,7 @@ class InfectionActivity : GameActivity() {
         rng = intent.getSerializableExtra(InfectionActivity.RANDOM_SOURCE) as Random
         seed = intent.getLongExtra(SEED, 0)
         binding.seedDisplay.text = "Seed: $seed"
+        binding.currentPlayerRole.text = gameState!!.players[gameState!!.curPlayer].role.name
 
         val result = gameState!!.executeTransition(Transition.INFECT, rng!!)
                 as TrackableState.TransitionResult.Success.InfectionTransitionResult

--- a/app/src/main/res/layout/activity_draw_player_cards.xml
+++ b/app/src/main/res/layout/activity_draw_player_cards.xml
@@ -6,6 +6,18 @@
     android:layout_height="match_parent"
     tools:context=".DrawPlayerCards">
 
+    <TextView
+        android:id="@+id/currentPlayerRole"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="16dp"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <ScrollView
         android:id="@+id/scrollView"
         android:layout_width="0dp"
@@ -13,7 +25,7 @@
         app:layout_constraintBottom_toTopOf="@+id/proceedToInfectionPhase"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toBottomOf="@+id/currentPlayerRole">
 
         <LinearLayout
             android:id="@+id/cardsContainer"

--- a/app/src/main/res/layout/activity_infection.xml
+++ b/app/src/main/res/layout/activity_infection.xml
@@ -6,17 +6,29 @@
     android:layout_height="match_parent"
     tools:context=".InfectionActivity">
 
+    <TextView
+        android:id="@+id/currentPlayerRole"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="16dp"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <LinearLayout
         android:id="@+id/infectedCities"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
+        android:layout_marginTop="16dp"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
         android:orientation="vertical"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/currentPlayerRole" />
 
     <Button
         android:id="@+id/nextTurn"


### PR DESCRIPTION
Fixes #58

## Summary

The "current player" role indicator was only shown on the turn-timer screen. Once the turn progressed to Draw Player Cards and then to the Infection phase, the indicator disappeared, so players lost track of whose turn it was — especially during the infection phase, as called out in the issue.

- Added the same pinned `currentPlayerRole` header (matching the style already used in `TurnTimer`) to `activity_draw_player_cards.xml` and `activity_infection.xml`, positioned outside/above the scrollable content so it stays fixed on screen regardless of scroll position.
- Set the header text in `DrawPlayerCards.kt` and `InfectionActivity.kt` from `gameState.players[gameState.curPlayer].role.name`, the same expression already used in `TurnTimer.kt`.

## Test plan

- [x] `./gradlew :pandemic-generator-core:test` passes (unaffected by this change; ran via a system-installed Gradle since the wrapper distribution download was blocked in this sandbox).
- [ ] `app` module unit/instrumented tests and a manual walkthrough of the Draw Cards → Infection flow were not run — this environment has no Android SDK configured, so the `app` module can't be built or tested here. The change mirrors the existing, tested `currentPlayerRole` pattern from `TurnTimer` (see `NavigationTest.turnTimerDisplaysCurrentPlayerRole`), but should be sanity-checked in a device/emulator before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WatQmmy8CpTVUHL87WZkFP)_