### PR TITLE
Fix turn timer briefly displaying -1 second

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
@@ -17,6 +17,7 @@ class TurnTimer : GameActivity() {
     private var gameState: TrackableState? = null
     private var rng: Random? = null
     private var seed: Long = 0
+    private var timerExpired = false
 
     companion object {
         const val GAME_STATE = "game_state"
@@ -51,13 +52,22 @@ class TurnTimer : GameActivity() {
             binding.timeRemaining.onChronometerTickListener = Chronometer.OnChronometerTickListener {
                 val timeTilTarget = targetTime - SystemClock.elapsedRealtime()
                 if (timeTilTarget <= 0) {
-                    try {
-                        val notification = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
-                        val r = RingtoneManager.getRingtone(applicationContext, notification)
-                        r.play()
-                        binding.timeRemaining.stop()
-                    } catch (e: Exception) {
-                        e.printStackTrace()
+                    // Chronometer computes its own displayed text from the current clock
+                    // reading as part of every tick, independently of this listener. If we
+                    // let that happen, it can render a negative time (e.g. "-0:01") for one
+                    // tick before stop() takes effect. Force the text to a clean zero state
+                    // immediately so nothing negative is ever visible, then stop the timer.
+                    binding.timeRemaining.text = "0:00"
+                    binding.timeRemaining.stop()
+                    if (!timerExpired) {
+                        timerExpired = true
+                        try {
+                            val notification = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM)
+                            val r = RingtoneManager.getRingtone(applicationContext, notification)
+                            r.play()
+                        } catch (e: Exception) {
+                            e.printStackTrace()
+                        }
                     }
                 } else if (timeTilTarget <= 10 * 1000) {
                     window.decorView.setBackgroundColor(Color.RED)


### PR DESCRIPTION
Fixes #54

## Root cause

`android.widget.Chronometer` computes and renders its own displayed text on every tick (based on `base - SystemClock.elapsedRealtime()` since `isCountDown` is true), using its *own* internal clock read. `onChronometerTickListener` fires as an **additional** hook on the same tick — it does not gate or replace the widget's internal text render.

In the old code, the listener read `SystemClock.elapsedRealtime()` a moment after the widget's own internal read for that same tick, and called `binding.timeRemaining.stop()` only once `timeTilTarget <= 0`. But `stop()` only prevents the *next* scheduled tick from firing — it does not retroactively undo the text the widget already rendered for the current tick. Because of the two separate (and slightly offset) clock reads, and because `stop()`'s effect is only visible starting the following tick, the widget could:

- render a negative value (e.g. "-0:01") for one tick before `stop()` took effect, or
- in the worst case, have `stop()`'s effect land one tick too late and freeze permanently on a negative value — matching both symptoms described in the issue ("briefly (or permanently)").

## Fix

In `app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt`, as soon as the listener detects `timeTilTarget <= 0`:

1. Explicitly set `binding.timeRemaining.text = "0:00"` *before* calling `stop()`. This means even if the Chronometer's own internal render for that tick already happened (or happens on a subsequent tick before `stop()` takes effect), our explicit text assignment overwrites it with a clean zero state. The widget no longer has a chance to leave a negative string visible to the user.
2. Call `stop()` immediately after, so no further ticks (and thus no further internal negative-value renders) can occur.
3. Added a `timerExpired` boolean flag so the ringtone-playing / "time up" logic only runs once. Previously this logic lived entirely inside the `timeTilTarget <= 0` branch of a *recurring* listener; if `stop()`'s effect were ever delayed by a tick (the same race described above), the ringtone could fire more than once. The flag makes the expiry callback idempotent regardless of how many more times the listener happens to run with `timeTilTarget <= 0`.

The `"0:00"` string matches the format `Chronometer` naturally produces via `DateUtils.formatElapsedTime` for a zero-second countdown (unpadded minutes, e.g. `"0:00"`, `"1:23"`), so there's no visible format change for the terminal state — only the negative flash is eliminated.

The diff is intentionally minimal and scoped only to this bug; no other logic in `TurnTimer.kt` (background color changes, activity navigation, etc.) was touched.

## Testing note

This sandbox has no Android SDK installed (`ANDROID_HOME`/`local.properties` `sdk.dir` unset), so the `app` module cannot be compiled or have its (nonexistent) UI tests run here — `TurnTimer.kt` has no existing automated coverage for `Chronometer` tick timing, and setting up an instrumented test harness was out of scope for this fix. I verified this change by careful manual inspection against the documented behavior of `Chronometer`/`OnChronometerTickListener` (text render happens per-tick independent of the listener; `stop()` only affects future ticks) rather than a runnable test. The change is a small, self-contained edit (set text, then stop, then guard the one-time side effect) with no new control flow paths beyond the added idempotency flag, which should make correctness straightforward to confirm by reading the diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeiVDD96CqZ8s67A3txQq5)_