### PR TITLE
Explain Virulent Strain determination on first Epidemic

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/CityDisplay.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/CityDisplay.kt
@@ -11,6 +11,7 @@ import org.gabbard.pandemicgenerator.CityPlayerCard
 import org.gabbard.pandemicgenerator.Epidemic
 import org.gabbard.pandemicgenerator.EventCard
 import org.gabbard.pandemicgenerator.PlayerCard
+import org.gabbard.pandemicgenerator.seededColorTiebreakOrder
 import org.gabbard.pandemicgenerator.Color as GameColor
 
 fun GameColor.toAndroidColor(): Int = when (this) {
@@ -76,4 +77,32 @@ fun LinearLayout.addSectionHeader(text: String) {
         setTextColor(android.graphics.Color.GRAY)
         setPadding(0, (14 * dp).toInt(), 0, (4 * dp).toInt())
     })
+}
+
+fun LinearLayout.addTextRow(text: String) {
+    val dp = context.resources.displayMetrics.density
+    addView(TextView(context).apply {
+        this.text = text
+        textSize = 13f
+        setPadding(0, (2 * dp).toInt(), 0, (2 * dp).toInt())
+    })
+}
+
+/**
+ * Explains, for the first Virulent Strain epidemic drawn in a game, how to determine which
+ * disease color becomes virulent. Cube counts are compared only after the city drawn from the
+ * bottom of the infection deck (shown just above this note) has had its cubes placed, and ties
+ * are broken using a color ranking seeded from this game's seed so it's reproducible.
+ */
+fun LinearLayout.addFirstEpidemicVirulentStrainExplanation(seed: Long) {
+    addSectionHeader("Virulent Strain determination")
+    addTextRow(
+        "This is the first Epidemic, so it determines which disease becomes virulent for " +
+            "the rest of the game. Count cubes on the board AFTER placing cubes for the city " +
+            "just infected from the bottom of the infection deck above. The color with the " +
+            "most cubes becomes the virulent strain."
+    )
+    val tiebreakOrder = seededColorTiebreakOrder(seed).joinToString(" > ") { it.name }
+    addTextRow("If there is a tie, use this seeded color ranking to break it:")
+    addTextRow("Using randomly seeded color ranking: $tiebreakOrder")
 }

--- a/app/src/main/java/gabbard/org/pandemicgenerator/GameLogActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/GameLogActivity.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import gabbard.org.pandemicgenerator.databinding.ActivityGameLogBinding
 import org.gabbard.pandemicgenerator.GameEvent
 import org.gabbard.pandemicgenerator.TrackableState
+import org.gabbard.pandemicgenerator.seededColorTiebreakOrder
 
 class GameLogActivity : AppCompatActivity() {
     private lateinit var binding: ActivityGameLogBinding
@@ -30,6 +31,7 @@ class GameLogActivity : AppCompatActivity() {
         if (log.isEmpty()) {
             container.addSectionHeader("No events yet")
         } else {
+            var isFirstEpidemicOfGame = true
             log.forEachIndexed { index, event ->
                 when (event) {
                     is GameEvent.DrawPlayerCardsEvent -> {
@@ -38,6 +40,10 @@ class GameLogActivity : AppCompatActivity() {
                         for ((epidemic, city) in event.epidemicsAndInfectedCities) {
                             container.addSectionHeader("Epidemic: ${epidemic.userString}")
                             container.addCityRow(city, "infected from bottom")
+                            if (isFirstEpidemicOfGame) {
+                                container.addFirstEpidemicVirulentStrainExplanation(seed)
+                                isFirstEpidemicOfGame = false
+                            }
                         }
                     }
                     is GameEvent.InfectionEvent -> {

--- a/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/City.kt
+++ b/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/City.kt
@@ -1,9 +1,23 @@
 package org.gabbard.pandemicgenerator
 
 import java.io.Serializable
+import java.util.Random
 
 enum class Color {
     BLUE, YELLOW, BLACK, RED
+}
+
+/**
+ * Returns a deterministic ordering of all four [Color] values, seeded from [seed].
+ *
+ * This is used to break ties when determining which disease becomes "virulent" under the
+ * Virulent Strain challenge (see [Epidemic]): if multiple colors are tied for the most cubes
+ * on the board when the first epidemic is resolved, the color that sorts earliest in this list
+ * wins. Because the ordering is derived solely from the game's seed, it is reproducible for a
+ * given game without needing to be stored anywhere.
+ */
+fun seededColorTiebreakOrder(seed: Long): List<Color> {
+    return Color.entries.shuffled(Random(seed))
 }
 
 data class City(val name: String, val color: Color) : Serializable {

--- a/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/SeededColorTiebreakOrderTest.kt
+++ b/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/SeededColorTiebreakOrderTest.kt
@@ -1,0 +1,25 @@
+package org.gabbard.pandemicgenerator
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SeededColorTiebreakOrderTest {
+
+    @Test
+    fun isDeterministicForAGivenSeed() {
+        assertEquals(seededColorTiebreakOrder(42L), seededColorTiebreakOrder(42L))
+    }
+
+    @Test
+    fun containsAllFourColorsExactlyOnce() {
+        val order = seededColorTiebreakOrder(1234L)
+        assertEquals(Color.entries.toSet(), order.toSet())
+        assertEquals(4, order.size)
+    }
+
+    @Test
+    fun differentSeedsCanProduceDifferentOrderings() {
+        val orderings = (0L until 20L).map { seededColorTiebreakOrder(it) }.toSet()
+        assertEquals(true, orderings.size > 1)
+    }
+}


### PR DESCRIPTION
Fixes #56

## Summary

Players using the Virulent Strain challenge sometimes aren't sure how to determine which disease becomes virulent when the first Epidemic is drawn, especially when cube counts are tied. This adds a clarifying note to the Game Log the first time an Epidemic is drawn in a game:

- States that this Epidemic determines the Virulent Strain disease.
- Clarifies that cube counts used for the determination are counted **after** the city drawn from the bottom of the infection deck (shown just above the note) has had its cubes placed.
- States the tiebreak rule, and shows the actual tiebreak color ordering to use if there's a tie (e.g. `Using randomly seeded color ranking: RED > BLUE > BLACK > YELLOW`).

## Scope decision

Computing exact live per-color cube totals at that point in the game would require plumbing the initial 3/2/1 cube-seeding data (currently only surfaced in `InitialSetup.kt`) into `TrackableState.eventLog`/`GameLogActivity` — a larger architectural change that's out of scope here and is tracked separately by issue #52. `UntrackableState` (board cube counts) is explicitly "not updated during play" per this project's design (see CLAUDE.md), so a fully-accurate running cube count isn't reachable without that larger change. Given that, this PR ships the minimal, clearly-correct fix: the explanatory text plus a **seeded, reproducible tiebreak ordering**, which is a complete and correct fix for the ambiguity the issue reports (how ties should be resolved), without overreaching into #52's territory.

The tiebreak ordering is deterministic per-game: `seededColorTiebreakOrder(seed: Long): List<Color>` in `pandemic-generator-core` shuffles the 4 `Color` values with `Color.entries.shuffled(Random(seed))`, so re-opening the Game Log for the same game always shows the same ranking. It's unit-tested in `SeededColorTiebreakOrderTest.kt` (determinism, contains-all-four-colors-once, and that different seeds can differ).

## Changes

- `pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/City.kt`: add `seededColorTiebreakOrder(seed: Long): List<Color>`.
- `pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/SeededColorTiebreakOrderTest.kt`: new unit test for the above.
- `app/src/main/java/gabbard/org/pandemicgenerator/CityDisplay.kt`: add `addTextRow` (plain body-text row helper) and `addFirstEpidemicVirulentStrainExplanation` (renders the explanatory section).
- `app/src/main/java/gabbard/org/pandemicgenerator/GameLogActivity.kt`: track the first Epidemic across the whole `eventLog` (not per-screen) and render the explanation immediately after it.

## Verification

This sandbox has no Android SDK installed (no `ANDROID_HOME`/`local.properties`), so the `app` module cannot be compiled or have its tests run here — only `pandemic-generator-core` can. I:

- Ran `gradle :pandemic-generator-core:test` — all tests pass, including the new `SeededColorTiebreakOrderTest`.
- Hand-wrote and carefully reviewed the `app`-module Kotlin changes, closely mirroring the existing style/patterns in `CityDisplay.kt` and `GameLogActivity.kt` (same extension-function style, same `LinearLayout` receiver pattern, same import conventions) since they could not be compiled locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WeiVDD96CqZ8s67A3txQq5)_