### PR TITLE
Group game log by turn and player instead of flat event list

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/GameLogActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/GameLogActivity.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import gabbard.org.pandemicgenerator.databinding.ActivityGameLogBinding
 import org.gabbard.pandemicgenerator.GameEvent
+import org.gabbard.pandemicgenerator.Player
 import org.gabbard.pandemicgenerator.TrackableState
 
 class GameLogActivity : AppCompatActivity() {
@@ -30,10 +31,20 @@ class GameLogActivity : AppCompatActivity() {
         if (log.isEmpty()) {
             container.addSectionHeader("No events yet")
         } else {
-            log.forEachIndexed { index, event ->
+            // Group the chronological event log into per-turn sections: a turn begins
+            // whenever a player draws cards, or whenever the acting player changes (which
+            // can only happen at a turn boundary), so a player's draw and the infection
+            // that follows it are shown together under a single "Turn N — <Player>" header.
+            var turnNumber = 0
+            var lastPlayer: Player? = null
+            log.forEach { event ->
+                if (event is GameEvent.DrawPlayerCardsEvent || event.player != lastPlayer) {
+                    turnNumber++
+                    container.addSectionHeader("Turn $turnNumber — ${event.player.role.name}")
+                }
+                lastPlayer = event.player
                 when (event) {
                     is GameEvent.DrawPlayerCardsEvent -> {
-                        container.addSectionHeader("Event ${index + 1}: Drew Player Cards")
                         event.cardsDrawn.forEach { container.addPlayerCardRow(it) }
                         for ((epidemic, city) in event.epidemicsAndInfectedCities) {
                             container.addSectionHeader("Epidemic: ${epidemic.userString}")
@@ -41,7 +52,6 @@ class GameLogActivity : AppCompatActivity() {
                         }
                     }
                     is GameEvent.InfectionEvent -> {
-                        container.addSectionHeader("Event ${index + 1}: Infection")
                         event.infectedCities.forEach { container.addCityRow(it) }
                     }
                 }

--- a/app/src/test/java/gabbard/org/pandemicgenerator/GameLogActivityTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/GameLogActivityTest.kt
@@ -71,7 +71,8 @@ class GameLogActivityTest {
                 // At least the section header was added
                 assertTrue(container.childCount > 0)
                 val header = container.getChildAt(0) as TextView
-                assertTrue(header.text.contains("Drew Player Cards"))
+                assertTrue(header.text.contains("Turn 1"))
+                assertTrue(header.text.contains("Medic"))
             }
         }
     }
@@ -83,7 +84,7 @@ class GameLogActivityTest {
             scenario.onActivity { activity ->
                 val container = activity.findViewById<LinearLayout>(R.id.eventLogContainer)
                 val header = container.getChildAt(0) as TextView
-                assertTrue("Header should say Event 1", header.text.contains("Event 1"))
+                assertTrue("Header should say Turn 1", header.text.contains("Turn 1"))
             }
         }
     }
@@ -98,13 +99,13 @@ class GameLogActivityTest {
                 val container = activity.findViewById<LinearLayout>(R.id.eventLogContainer)
                 assertTrue(container.childCount > 0)
                 val header = container.getChildAt(0) as TextView
-                assertTrue(header.text.contains("Infection"))
+                assertTrue(header.text.contains("Turn 1"))
             }
         }
     }
 
     @Test
-    fun multipleEventsAreNumberedSequentially() {
+    fun drawAndInfectFromSamePlayerShareOneTurnHeader() {
         val afterDraw = stateAfterDraw()
         val afterInfect = stateAfterInfect(afterDraw)
         assertEquals(2, afterInfect.eventLog.size)
@@ -116,8 +117,34 @@ class GameLogActivityTest {
                     .map { container.getChildAt(it) }
                     .filterIsInstance<TextView>()
                     .map { it.text.toString() }
-                assertTrue(headers.any { it.contains("Event 1") })
-                assertTrue(headers.any { it.contains("Event 2") })
+                // The draw and the infection that follows it belong to the same player's
+                // turn, so they should be grouped under a single "Turn 1" header rather
+                // than being numbered as two separate events.
+                assertEquals(1, headers.count { it.contains("Turn 1") })
+                assertTrue(headers.none { it.contains("Turn 2") })
+            }
+        }
+    }
+
+    @Test
+    fun secondPlayersTurnGetsItsOwnHeader() {
+        // Simulate a full round: player 0 draws + infects, then player 1 draws.
+        val afterFirstDraw = stateAfterDraw()
+        val afterFirstInfect = stateAfterInfect(afterFirstDraw)
+        val afterSecondDraw = (afterFirstInfect.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult)
+            .newGameState
+        assertEquals(3, afterSecondDraw.eventLog.size)
+
+        ActivityScenario.launch<GameLogActivity>(intentFor(afterSecondDraw)).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = activity.findViewById<LinearLayout>(R.id.eventLogContainer)
+                val headers = (0 until container.childCount)
+                    .map { container.getChildAt(it) }
+                    .filterIsInstance<TextView>()
+                    .map { it.text.toString() }
+                assertTrue(headers.any { it.contains("Turn 1") && it.contains("Medic") })
+                assertTrue(headers.any { it.contains("Turn 2") && it.contains("Scientist") })
             }
         }
     }
@@ -130,7 +157,8 @@ class GameLogActivityTest {
         val city = cities[0]
         val event = GameEvent.DrawPlayerCardsEvent(
             cardsDrawn = listOf(epidemic, CityPlayerCard(cities[1])),
-            epidemicsAndInfectedCities = listOf(epidemic to city)
+            epidemicsAndInfectedCities = listOf(epidemic to city),
+            player = Player(Role("Medic"))
         )
         val state = makeState(eventLog = listOf(event))
         ActivityScenario.launch<GameLogActivity>(intentFor(state)).use { scenario ->

--- a/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/GameState.kt
+++ b/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/GameState.kt
@@ -33,10 +33,17 @@ data class CityState(val infections: Map<Color, Int>) : Serializable {
 data class BoardState(val cityStates: Map<City, CityState>) : Serializable
 
 sealed class GameEvent : Serializable {
-    data class InfectionEvent(val infectedCities: List<City>) : GameEvent()
+    abstract val player: Player
+
+    data class InfectionEvent(
+        val infectedCities: List<City>,
+        override val player: Player
+    ) : GameEvent()
+
     data class DrawPlayerCardsEvent(
         val cardsDrawn: List<PlayerCard>,
-        val epidemicsAndInfectedCities: List<Pair<Epidemic, City>>
+        val epidemicsAndInfectedCities: List<Pair<Epidemic, City>>,
+        override val player: Player
     ) : GameEvent()
 }
 
@@ -84,7 +91,7 @@ data class TrackableState(val curPlayer: Int,
         when (transition) {
             Transition.INFECT -> {
                 val infectionResult = infect()
-                val event = GameEvent.InfectionEvent(infectionResult.infectedCities)
+                val event = GameEvent.InfectionEvent(infectionResult.infectedCities, players[curPlayer])
                 return TransitionResult.Success.InfectionTransitionResult(
                         infectionResult.newGameState.copy(
                                 curPlayer = (curPlayer + 1) % players.size,
@@ -106,7 +113,7 @@ data class TrackableState(val curPlayer: Int,
                     curState = postEpidemicGameState
                     epidemicsToCitiesInfected.add(Pair(epidemic, newCity))
                 }
-                val event = GameEvent.DrawPlayerCardsEvent(cardsDrawn, epidemicsToCitiesInfected)
+                val event = GameEvent.DrawPlayerCardsEvent(cardsDrawn, epidemicsToCitiesInfected, players[curPlayer])
                 return TransitionResult.Success.DrawPlayerCardsTransitionResult(
                         curState.copy(
                                 lastTransition = transition,

--- a/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/TrackableStateTest.kt
+++ b/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/TrackableStateTest.kt
@@ -228,6 +228,47 @@ class TrackableStateTest {
         assertTrue(state.eventLog.isEmpty())
     }
 
+    @Test
+    fun infectionEventRecordsActingPlayer() {
+        val state = makeState(lastTransition = Transition.DRAW_PLAYER_CARDS)
+        val result = state.executeTransition(Transition.INFECT, rng)
+                as TrackableState.TransitionResult.Success.InfectionTransitionResult
+        val event = result.newGameState.eventLog[0] as GameEvent.InfectionEvent
+        assertEquals(state.players[state.curPlayer], event.player)
+    }
+
+    @Test
+    fun drawPlayerCardsEventRecordsActingPlayer() {
+        val cityCards = ALL_CITIES.take(5).map { CityPlayerCard(it) }
+        val state = makeState(playerCards = cityCards, lastTransition = Transition.INFECT)
+        val result = state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult
+        val event = result.newGameState.eventLog[0] as GameEvent.DrawPlayerCardsEvent
+        assertEquals(state.players[state.curPlayer], event.player)
+    }
+
+    @Test
+    fun eventLogAttributesEventsToCorrectPlayerAcrossTurns() {
+        val cityCards = ALL_CITIES.take(5).map { CityPlayerCard(it) }
+        val state = makeState(playerCards = cityCards, lastTransition = Transition.INFECT)
+        val medic = state.players[0]
+        val scientist = state.players[1]
+
+        val afterDraw = (state.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.Success).newGameState
+        val afterInfect = (afterDraw.executeTransition(Transition.INFECT, rng)
+                as TrackableState.TransitionResult.Success).newGameState
+        val afterDraw2 = (afterInfect.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.Success).newGameState
+
+        assertEquals(3, afterDraw2.eventLog.size)
+        // First turn (draw + infect) belongs to the player who was current before infect advanced curPlayer.
+        assertEquals(medic, afterDraw2.eventLog[0].player)
+        assertEquals(medic, afterDraw2.eventLog[1].player)
+        // Second turn's draw belongs to the next player.
+        assertEquals(scientist, afterDraw2.eventLog[2].player)
+    }
+
     // ── player deck exhaustion ───────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Fixes #57

## Summary

The Game Log screen previously rendered each raw transition (a card draw or an infection) as its own flat, numbered "Event N: ..." section, in the order the transitions occurred. The underlying `eventLog` list was already chronological — the real problem was presentational: a player's card draw and the infection that immediately followed it (i.e. their whole turn) were split into separate, unlabeled sections with no indication of which player acted, making it hard to follow a past game as a narrative turn-by-turn history.

## Changes

- `pandemic-generator-core`: `GameEvent` (`InfectionEvent` and `DrawPlayerCardsEvent`) now carries the acting `player`, set from `players[curPlayer]` at the point each event is appended in `TrackableState.executeTransition`.
- `app`: `GameLogActivity` now groups the chronologically-ordered event log into per-turn sections headed `"Turn N — <Player Role>"`. A new turn header is emitted whenever a `DrawPlayerCardsEvent` occurs or the acting player changes, so a player's draw and their subsequent infection results are grouped together under one header, reusing the existing `addSectionHeader`/`addPlayerCardRow`/`addCityRow` helpers in `CityDisplay.kt`.
- Updated `pandemic-generator-core/.../TrackableStateTest.kt` with new tests asserting events are attributed to the correct player, including across a full turn cycle (player 0's draw+infect vs. player 1's draw).
- Updated `app/.../GameLogActivityTest.kt` by hand to match the new turn-grouped header format (e.g. asserting a single "Turn 1" header spans both a draw and its following infection, and that a second player's turn gets its own "Turn 2" header), and to pass the new required `player` constructor argument where a `GameEvent` is built manually in a test.

## Verification

This sandbox has no Android SDK installed (no `ANDROID_HOME`/`local.properties`), so the `app` module cannot be compiled or have its tests run here — only `pandemic-generator-core` is buildable in this environment. I verified:

- `gradle :pandemic-generator-core:test` passes in full (133 tests, 0 failures), including the new player-attribution tests in `TrackableStateTest.kt`.
- The `app` module changes (`GameLogActivity.kt` and `GameLogActivityTest.kt`) were written and reviewed carefully by hand against the existing code style and the helper extension functions already defined in `CityDisplay.kt`, and traced through by hand for the relevant scenarios (empty log, single draw, single infect, draw+infect same turn, two players' turns, and the manually-constructed epidemic event case) to confirm the expected header text and grouping.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WeiVDD96CqZ8s67A3txQq5)_