### PR TITLE
Add local history of recently used game seeds

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/EnterRandomSeed.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/EnterRandomSeed.kt
@@ -1,5 +1,6 @@
 package gabbard.org.pandemicgenerator
 
+import android.app.AlertDialog
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
@@ -29,10 +30,35 @@ class EnterRandomSeed : AppCompatActivity() {
             val seed = abs(Random().nextLong()) % 1_000_000L
             binding.startGame.setText(seed.toString())
         }
+
+        binding.recentSeedsButton.setOnClickListener {
+            showRecentSeedsDialog()
+        }
+    }
+
+    private fun showRecentSeedsDialog() {
+        val recentSeeds = SeedHistory.recentSeeds(this)
+        if (recentSeeds.isEmpty()) {
+            AlertDialog.Builder(this)
+                .setTitle("Recent Seeds")
+                .setMessage("No recent seeds yet.")
+                .setPositiveButton("OK", null)
+                .show()
+            return
+        }
+
+        val items = recentSeeds.map { it.toString() }.toTypedArray()
+        AlertDialog.Builder(this)
+            .setTitle("Recent Seeds")
+            .setItems(items) { _, which ->
+                binding.startGame.setText(items[which])
+            }
+            .show()
     }
 
     fun startGame(@Suppress("UNUSED_PARAMETER") view: View) {
         val seed = binding.startGame.text.toString().toLong()
+        SeedHistory.record(this, seed)
         startActivity(Intent(this, InitialSetup::class.java).apply {
             putExtra(InitialSetup.GAME_RULES, gameRules)
             putExtra(InitialSetup.RANDOM_SOURCE, Random(seed))

--- a/app/src/main/java/gabbard/org/pandemicgenerator/SeedHistory.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/SeedHistory.kt
@@ -1,0 +1,45 @@
+package gabbard.org.pandemicgenerator
+
+import android.content.Context
+
+/**
+ * Stores the most recently used random seeds so players can replay a past setup or share a
+ * seed with a friend without having to write it down. Backed by [android.content.SharedPreferences],
+ * mirroring the persistence approach used elsewhere in the app (see [GameRepository]).
+ */
+object SeedHistory {
+    private const val PREFS_NAME = "seed_history"
+    private const val KEY_SEEDS = "recent_seeds"
+    private const val SEPARATOR = ","
+
+    // A reasonable midpoint of the "store the last 10-20 seeds" request.
+    private const val MAX_ENTRIES = 15
+
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    /** Returns the recorded seeds, most-recently-used first. */
+    fun recentSeeds(context: Context): List<Long> =
+        prefs(context).getString(KEY_SEEDS, null)
+            ?.split(SEPARATOR)
+            ?.filter { it.isNotBlank() }
+            ?.mapNotNull { it.toLongOrNull() }
+            ?: emptyList()
+
+    /**
+     * Records [seed] as the most recently used seed. If [seed] is already present in the
+     * history, it is moved to the front rather than stored as a duplicate. The history is
+     * capped at [MAX_ENTRIES] entries, dropping the oldest seeds first.
+     */
+    fun record(context: Context, seed: Long) {
+        val updated = (listOf(seed) + recentSeeds(context).filter { it != seed }).take(MAX_ENTRIES)
+        prefs(context).edit()
+            .putString(KEY_SEEDS, updated.joinToString(SEPARATOR))
+            .apply()
+    }
+
+    /** Clears the seed history. Exposed primarily for tests. */
+    fun clear(context: Context) {
+        prefs(context).edit().remove(KEY_SEEDS).apply()
+    }
+}

--- a/app/src/main/res/layout/activity_enter_random_seed.xml
+++ b/app/src/main/res/layout/activity_enter_random_seed.xml
@@ -53,4 +53,14 @@
         app:layout_constraintStart_toEndOf="@+id/randomSeedButton"
         app:layout_constraintTop_toBottomOf="@+id/startGame" />
 
+    <Button
+        android:id="@+id/recentSeedsButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Recent Seeds"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/randomSeedButton" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/gabbard/org/pandemicgenerator/EnterRandomSeedTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/EnterRandomSeedTest.kt
@@ -1,10 +1,12 @@
 package gabbard.org.pandemicgenerator
 
+import android.content.Context
 import android.content.Intent
 import android.widget.EditText
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import org.gabbard.pandemicgenerator.NATIONAL_CHAMPIONSHIP_RULES
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -13,10 +15,18 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowAlertDialog
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33])
 class EnterRandomSeedTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @After
+    fun tearDown() {
+        SeedHistory.clear(context)
+    }
 
     private fun intent(): Intent =
         Intent(ApplicationProvider.getApplicationContext(), EnterRandomSeed::class.java).apply {
@@ -101,6 +111,57 @@ class EnterRandomSeedTest {
                 @Suppress("DEPRECATION")
                 val rules = started.getSerializableExtra(InitialSetup.GAME_RULES)
                 assertEquals(NATIONAL_CHAMPIONSHIP_RULES, rules)
+            }
+        }
+    }
+
+    // ── recent seeds ───────────────────────────────────────────────────────────
+
+    @Test
+    fun startGameRecordsSeedInHistory() {
+        ActivityScenario.launch<EnterRandomSeed>(intent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<EditText>(R.id.startGame).setText("54321")
+                activity.findViewById<android.view.View>(R.id.button2).performClick()
+            }
+        }
+        assertEquals(listOf(54321L), SeedHistory.recentSeeds(context))
+    }
+
+    @Test
+    fun recentSeedsButtonShowsEmptyStateWhenNoHistory() {
+        ActivityScenario.launch<EnterRandomSeed>(intent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<android.view.View>(R.id.recentSeedsButton).performClick()
+                val dialog = ShadowAlertDialog.getLatestAlertDialog()
+                assertEquals("No recent seeds yet.", shadowOf(dialog).message)
+            }
+        }
+    }
+
+    @Test
+    fun recentSeedsButtonShowsHistoryWhenPresent() {
+        SeedHistory.record(context, 111L)
+        SeedHistory.record(context, 222L)
+        ActivityScenario.launch<EnterRandomSeed>(intent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<android.view.View>(R.id.recentSeedsButton).performClick()
+                val dialog = ShadowAlertDialog.getLatestAlertDialog()
+                val items = shadowOf(dialog).items.map { it.toString() }
+                assertEquals(listOf("222", "111"), items)
+            }
+        }
+    }
+
+    @Test
+    fun selectingRecentSeedPopulatesSeedField() {
+        SeedHistory.record(context, 777L)
+        ActivityScenario.launch<EnterRandomSeed>(intent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<android.view.View>(R.id.recentSeedsButton).performClick()
+                shadowOf(ShadowAlertDialog.getLatestAlertDialog()).clickOnItem(0)
+                val text = activity.findViewById<EditText>(R.id.startGame).text.toString()
+                assertEquals("777", text)
             }
         }
     }

--- a/app/src/test/java/gabbard/org/pandemicgenerator/SeedHistoryTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/SeedHistoryTest.kt
@@ -1,0 +1,71 @@
+package gabbard.org.pandemicgenerator
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class SeedHistoryTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @After
+    fun tearDown() {
+        SeedHistory.clear(context)
+    }
+
+    // ── recentSeeds ───────────────────────────────────────────────────────────
+
+    @Test
+    fun recentSeedsIsEmptyByDefault() {
+        assertTrue(SeedHistory.recentSeeds(context).isEmpty())
+    }
+
+    @Test
+    fun recordAddsSeedToHistory() {
+        SeedHistory.record(context, 42L)
+        assertEquals(listOf(42L), SeedHistory.recentSeeds(context))
+    }
+
+    @Test
+    fun mostRecentlyRecordedSeedIsFirst() {
+        SeedHistory.record(context, 1L)
+        SeedHistory.record(context, 2L)
+        SeedHistory.record(context, 3L)
+        assertEquals(listOf(3L, 2L, 1L), SeedHistory.recentSeeds(context))
+    }
+
+    @Test
+    fun reRecordingASeedMovesItToFrontWithoutDuplicating() {
+        SeedHistory.record(context, 1L)
+        SeedHistory.record(context, 2L)
+        SeedHistory.record(context, 3L)
+        SeedHistory.record(context, 1L)
+        assertEquals(listOf(1L, 3L, 2L), SeedHistory.recentSeeds(context))
+    }
+
+    @Test
+    fun historyIsCappedAtFifteenEntries() {
+        (1L..20L).forEach { SeedHistory.record(context, it) }
+        val recent = SeedHistory.recentSeeds(context)
+        assertEquals(15, recent.size)
+        // Most recently recorded seeds (20 down to 6) should be kept, oldest dropped.
+        assertEquals((20L downTo 6L).toList(), recent)
+    }
+
+    // ── clear ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun clearRemovesAllHistory() {
+        SeedHistory.record(context, 1L)
+        SeedHistory.clear(context)
+        assertTrue(SeedHistory.recentSeeds(context).isEmpty())
+    }
+}


### PR DESCRIPTION
Fixes #53

## Summary

- Adds `SeedHistory` (`app/src/main/java/gabbard/org/pandemicgenerator/SeedHistory.kt`), a small `SharedPreferences`-backed helper that stores the last 15 seeds used to start a game, most-recent-first, deduplicated (re-using a seed moves it to the front instead of adding a duplicate entry). This mirrors the persistence style already used by `GameRepository` in this app, rather than introducing a new mechanism.
- `EnterRandomSeed.startGame()` now records the seed into `SeedHistory` every time a game is successfully launched.
- Adds a "Recent Seeds" button next to the existing "Random Seed" / "Start Game" buttons on the seed entry screen (`activity_enter_random_seed.xml`). Tapping it opens an `AlertDialog` list of past seeds (matching the `AlertDialog.Builder` style already used for the "End Game" confirmation in `GameActivity`), and picking one populates the seed input field — the same behavior as the existing "Random Seed" button. If there's no history yet, it shows a friendly "No recent seeds yet." message instead.
- Adds tests: `SeedHistoryTest.kt` (ordering, dedup, 15-entry cap, clear) and new cases in `EnterRandomSeedTest.kt` (recording on start, empty-state dialog, dialog contents, selecting an item populates the field).

## Note on verification

This sandbox has no Android SDK installed (no `ANDROID_HOME` / `local.properties` `sdk.dir`), so the `app` module cannot be compiled or have its Robolectric tests executed here — `./gradlew`/`gradle` for the `app` module fails with "SDK location not found". I verified `:pandemic-generator-core:test` still passes (unaffected by this change, since it doesn't touch the core module) and wrote/reviewed the Kotlin and XML changes carefully by hand, closely mirroring existing patterns in `GameRepository`, `GameActivity`'s `AlertDialog` usage, and the existing test files (`GameRepositoryTest.kt`, `EnterRandomSeedTest.kt`).

## Test plan

- [ ] `gradle :app:testDebugUnitTest` (requires Android SDK, not available in this sandbox) — please run in CI/locally to confirm `EnterRandomSeedTest` and `SeedHistoryTest` pass.
- [ ] Manual check: start a few games with different seeds, then confirm "Recent Seeds" lists them most-recent-first, re-using a seed doesn't duplicate it, and selecting an entry fills the seed field correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WeiVDD96CqZ8s67A3txQq5)_