### PR TITLE
Add seed, starting hands, and initial infections to Game Log

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
@@ -6,6 +6,7 @@ import android.view.View
 import gabbard.org.pandemicgenerator.databinding.ActivityDrawPlayerCardsBinding
 import org.gabbard.pandemicgenerator.TrackableState
 import org.gabbard.pandemicgenerator.Transition
+import org.gabbard.pandemicgenerator.UntrackableState
 import java.util.*
 
 class DrawPlayerCards : GameActivity() {
@@ -13,12 +14,14 @@ class DrawPlayerCards : GameActivity() {
     private var gameState: TrackableState? = null
     private var rng: Random? = null
     private var seed: Long = 0
+    private var initialState: UntrackableState? = null
 
     companion object {
         const val GAME_STATE = "game_state"
         const val RANDOM_SOURCE = "random_source"
         const val SEED = "seed"
         const val TURN_DURATION = "turn_duration"
+        const val INITIAL_STATE = "initial_state"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -30,6 +33,8 @@ class DrawPlayerCards : GameActivity() {
         @Suppress("DEPRECATION")
         rng = intent.getSerializableExtra(DrawPlayerCards.RANDOM_SOURCE) as Random
         seed = intent.getLongExtra(SEED, 0)
+        @Suppress("DEPRECATION")
+        initialState = intent.getSerializableExtra(INITIAL_STATE) as? UntrackableState
         binding.seedDisplay.text = "Seed: $seed"
         binding.currentPlayerRole.text = gameState!!.players[gameState!!.curPlayer].role.name
 
@@ -56,6 +61,7 @@ class DrawPlayerCards : GameActivity() {
 
     override fun gameStateForLog() = gameState
     override fun seedForLog() = seed
+    override fun initialStateForLog() = initialState
 
     fun onProceedToInfectionPhase(@Suppress("UNUSED_PARAMETER") view: View) {
         val infectionIntent = Intent(this, InfectionActivity::class.java)
@@ -63,6 +69,7 @@ class DrawPlayerCards : GameActivity() {
         infectionIntent.putExtra(InfectionActivity.RANDOM_SOURCE, rng!!)
         infectionIntent.putExtra(InfectionActivity.SEED, seed)
         infectionIntent.putExtra(InfectionActivity.TURN_DURATION, intent.getIntExtra(TURN_DURATION, TurnTimer.NO_TIMER))
+        initialState?.let { infectionIntent.putExtra(InfectionActivity.INITIAL_STATE, it) }
         startActivity(infectionIntent)
     }
 }

--- a/app/src/main/java/gabbard/org/pandemicgenerator/GameActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/GameActivity.kt
@@ -6,11 +6,13 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import org.gabbard.pandemicgenerator.TrackableState
+import org.gabbard.pandemicgenerator.UntrackableState
 
 abstract class GameActivity : AppCompatActivity() {
 
     protected open fun gameStateForLog(): TrackableState? = null
     protected open fun seedForLog(): Long = 0
+    protected open fun initialStateForLog(): UntrackableState? = null
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.menu_game, menu)
@@ -24,6 +26,7 @@ abstract class GameActivity : AppCompatActivity() {
                 startActivity(Intent(this, GameLogActivity::class.java).apply {
                     putExtra(GameLogActivity.GAME_STATE, state)
                     putExtra(GameLogActivity.SEED, seedForLog())
+                    initialStateForLog()?.let { putExtra(GameLogActivity.INITIAL_STATE, it) }
                 })
             }
             true

--- a/app/src/main/java/gabbard/org/pandemicgenerator/GameLogActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/GameLogActivity.kt
@@ -7,6 +7,7 @@ import gabbard.org.pandemicgenerator.databinding.ActivityGameLogBinding
 import org.gabbard.pandemicgenerator.GameEvent
 import org.gabbard.pandemicgenerator.Player
 import org.gabbard.pandemicgenerator.TrackableState
+import org.gabbard.pandemicgenerator.UntrackableState
 import org.gabbard.pandemicgenerator.seededColorTiebreakOrder
 
 class GameLogActivity : AppCompatActivity() {
@@ -15,6 +16,7 @@ class GameLogActivity : AppCompatActivity() {
     companion object {
         const val GAME_STATE = "game_state"
         const val SEED = "seed"
+        const val INITIAL_STATE = "initial_state"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -26,8 +28,31 @@ class GameLogActivity : AppCompatActivity() {
         val gameState = intent.getSerializableExtra(GAME_STATE) as TrackableState
         val seed = intent.getLongExtra(SEED, 0)
         binding.seedDisplay.text = "Seed: $seed"
+        @Suppress("DEPRECATION")
+        val initialState = intent.getSerializableExtra(INITIAL_STATE) as? UntrackableState
 
         val container = binding.eventLogContainer
+
+        if (initialState != null) {
+            container.addSectionHeader("Initialization")
+            container.addSectionHeader("Seed: $seed")
+
+            gameState.players.forEach { player ->
+                container.addSectionHeader("${player.role.name} starting hand:")
+                initialState.hands[player]?.sortedBy { it.userString }
+                    ?.forEach { container.addPlayerCardRow(it) }
+            }
+
+            val cityStates = initialState.board.cityStates
+            for (cubes in 3 downTo 1) {
+                val cities = cityStates.filterValues { it.infections.values.sum() == cubes }.keys
+                if (cities.isNotEmpty()) {
+                    container.addSectionHeader("$cubes cube${if (cubes == 1) "" else "s"} (initial):")
+                    cities.sortedBy { it.name }.forEach { container.addCityRow(it) }
+                }
+            }
+        }
+
         val log = gameState.eventLog
         if (log.isEmpty()) {
             container.addSectionHeader("No events yet")

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InfectionActivity.kt
@@ -6,6 +6,7 @@ import android.view.View
 import gabbard.org.pandemicgenerator.databinding.ActivityInfectionBinding
 import org.gabbard.pandemicgenerator.TrackableState
 import org.gabbard.pandemicgenerator.Transition
+import org.gabbard.pandemicgenerator.UntrackableState
 import java.util.*
 
 class InfectionActivity : GameActivity() {
@@ -13,12 +14,14 @@ class InfectionActivity : GameActivity() {
     private var gameState: TrackableState? = null
     private var rng: Random? = null
     private var seed: Long = 0
+    private var initialState: UntrackableState? = null
 
     companion object {
         const val GAME_STATE = "game_state"
         const val RANDOM_SOURCE = "random_source"
         const val SEED = "seed"
         const val TURN_DURATION = "turn_duration"
+        const val INITIAL_STATE = "initial_state"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -30,6 +33,8 @@ class InfectionActivity : GameActivity() {
         @Suppress("DEPRECATION")
         rng = intent.getSerializableExtra(InfectionActivity.RANDOM_SOURCE) as Random
         seed = intent.getLongExtra(SEED, 0)
+        @Suppress("DEPRECATION")
+        initialState = intent.getSerializableExtra(INITIAL_STATE) as? UntrackableState
         binding.seedDisplay.text = "Seed: $seed"
         binding.currentPlayerRole.text = gameState!!.players[gameState!!.curPlayer].role.name
 
@@ -43,6 +48,7 @@ class InfectionActivity : GameActivity() {
 
     override fun gameStateForLog() = gameState
     override fun seedForLog() = seed
+    override fun initialStateForLog() = initialState
 
     fun onNextTurn(@Suppress("UNUSED_PARAMETER") view: View) {
         val turnTimerIntent = Intent(this, TurnTimer::class.java)
@@ -50,6 +56,7 @@ class InfectionActivity : GameActivity() {
         turnTimerIntent.putExtra(TurnTimer.RANDOM_SOURCE, rng!!)
         turnTimerIntent.putExtra(TurnTimer.SEED, seed)
         turnTimerIntent.putExtra(TurnTimer.TURN_DURATION, intent.getIntExtra(TURN_DURATION, TurnTimer.NO_TIMER))
+        initialState?.let { turnTimerIntent.putExtra(TurnTimer.INITIAL_STATE, it) }
         startActivity(turnTimerIntent)
     }
 }

--- a/app/src/main/java/gabbard/org/pandemicgenerator/InitialSetup.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/InitialSetup.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.View
 import gabbard.org.pandemicgenerator.databinding.ActivityInitialSetupBinding
 import org.gabbard.pandemicgenerator.GameRules
+import org.gabbard.pandemicgenerator.UntrackableState
 import java.util.*
 
 
@@ -13,6 +14,7 @@ class InitialSetup : GameActivity() {
     private var gameRules: GameRules? = null
     private var rng: Random? = null
     private var seed: Long = 0
+    private var initialState: UntrackableState? = null
 
     companion object {
         const val GAME_RULES = "game_rules"
@@ -33,6 +35,7 @@ class InitialSetup : GameActivity() {
 
         val fullGameState = gameRules!!.setupGame(rng!!)
         val trackableState = fullGameState.trackableState
+        initialState = fullGameState.untrackableState
 
         val players = trackableState.players
         val hands = fullGameState.untrackableState.hands
@@ -68,6 +71,7 @@ class InitialSetup : GameActivity() {
             putExtra(TurnTimer.RANDOM_SOURCE, rng)
             putExtra(TurnTimer.SEED, seed)
             putExtra(TurnTimer.TURN_DURATION, gameRules!!.turnDurationSeconds ?: -1)
+            putExtra(TurnTimer.INITIAL_STATE, initialState)
         })
     }
 }

--- a/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/TurnTimer.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.widget.Chronometer
 import gabbard.org.pandemicgenerator.databinding.ActivityTurnTimerBinding
 import org.gabbard.pandemicgenerator.TrackableState
+import org.gabbard.pandemicgenerator.UntrackableState
 import java.util.*
 
 
@@ -18,6 +19,7 @@ class TurnTimer : GameActivity() {
     private var rng: Random? = null
     private var seed: Long = 0
     private var timerExpired = false
+    private var initialState: UntrackableState? = null
 
     companion object {
         const val GAME_STATE = "game_state"
@@ -25,6 +27,7 @@ class TurnTimer : GameActivity() {
         const val SEED = "seed"
         const val TURN_DURATION = "turn_duration"
         const val NO_TIMER = -1
+        const val INITIAL_STATE = "initial_state"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -36,6 +39,8 @@ class TurnTimer : GameActivity() {
         @Suppress("DEPRECATION")
         rng = intent.getSerializableExtra(RANDOM_SOURCE) as Random
         seed = intent.getLongExtra(SEED, 0)
+        @Suppress("DEPRECATION")
+        initialState = intent.getSerializableExtra(INITIAL_STATE) as? UntrackableState
         binding.seedDisplay.text = "Seed: $seed"
         binding.currentPlayerRole.text = gameState!!.players[gameState!!.curPlayer].role.name
 
@@ -80,6 +85,7 @@ class TurnTimer : GameActivity() {
 
     override fun gameStateForLog() = gameState
     override fun seedForLog() = seed
+    override fun initialStateForLog() = initialState
 
     fun onDrawPlayerCards(@Suppress("UNUSED_PARAMETER") view: View) {
         val drawPlayerCardsIntent = Intent(this, DrawPlayerCards::class.java)
@@ -87,6 +93,7 @@ class TurnTimer : GameActivity() {
         drawPlayerCardsIntent.putExtra(DrawPlayerCards.RANDOM_SOURCE, rng!!)
         drawPlayerCardsIntent.putExtra(DrawPlayerCards.SEED, seed)
         drawPlayerCardsIntent.putExtra(DrawPlayerCards.TURN_DURATION, intent.getIntExtra(TURN_DURATION, NO_TIMER))
+        initialState?.let { drawPlayerCardsIntent.putExtra(DrawPlayerCards.INITIAL_STATE, it) }
         startActivity(drawPlayerCardsIntent)
     }
 }

--- a/app/src/test/java/gabbard/org/pandemicgenerator/GameLogActivityTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/GameLogActivityTest.kt
@@ -239,7 +239,7 @@ class GameLogActivityTest {
             scenario.onActivity { activity ->
                 val headers = headerTexts(activity)
                 val initIndex = headers.indexOfFirst { it.contains("Initialization") }
-                val eventIndex = headers.indexOfFirst { it.contains("Event 1") }
+                val eventIndex = headers.indexOfFirst { it.contains("Turn 1") }
                 assertTrue("Initialization should come before the event log", initIndex in 0 until eventIndex)
             }
         }

--- a/app/src/test/java/gabbard/org/pandemicgenerator/GameLogActivityTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/GameLogActivityTest.kt
@@ -6,7 +6,10 @@ import android.widget.TextView
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import org.gabbard.pandemicgenerator.ALL_CITIES
+import org.gabbard.pandemicgenerator.BoardState
 import org.gabbard.pandemicgenerator.CityPlayerCard
+import org.gabbard.pandemicgenerator.CityState
+import org.gabbard.pandemicgenerator.Color
 import org.gabbard.pandemicgenerator.Deck
 import org.gabbard.pandemicgenerator.Epidemic
 import org.gabbard.pandemicgenerator.GameEvent
@@ -18,6 +21,7 @@ import org.gabbard.pandemicgenerator.PlayerCard
 import org.gabbard.pandemicgenerator.Role
 import org.gabbard.pandemicgenerator.TrackableState
 import org.gabbard.pandemicgenerator.Transition
+import org.gabbard.pandemicgenerator.UntrackableState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -173,6 +177,74 @@ class GameLogActivityTest {
         }
     }
 
+    // ── Initialization section ──────────────────────────────────────────────────
+
+    @Test
+    fun initializationSectionOmittedWhenInitialStateMissing() {
+        // No INITIAL_STATE extra is set by intentFor() by default, so the log should
+        // look exactly like it did before this feature: just the "No events yet" header.
+        val state = makeState()
+        ActivityScenario.launch<GameLogActivity>(intentFor(state)).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = activity.findViewById<LinearLayout>(R.id.eventLogContainer)
+                assertEquals(1, container.childCount)
+            }
+        }
+    }
+
+    @Test
+    fun initializationSectionAppearsWhenInitialStateProvided() {
+        val state = makeState()
+        val initialState = makeInitialState(state.players)
+        ActivityScenario.launch<GameLogActivity>(intentFor(state, initialState = initialState)).use { scenario ->
+            scenario.onActivity { activity ->
+                val headers = headerTexts(activity)
+                assertTrue("Initialization header should appear", headers.any { it.contains("Initialization") })
+            }
+        }
+    }
+
+    @Test
+    fun initializationSectionShowsStartingHandsForEachPlayer() {
+        val state = makeState()
+        val initialState = makeInitialState(state.players)
+        ActivityScenario.launch<GameLogActivity>(intentFor(state, initialState = initialState)).use { scenario ->
+            scenario.onActivity { activity ->
+                val headers = headerTexts(activity)
+                assertTrue("Medic starting hand header should appear", headers.any { it.contains("Medic starting hand") })
+                assertTrue("Scientist starting hand header should appear", headers.any { it.contains("Scientist starting hand") })
+            }
+        }
+    }
+
+    @Test
+    fun initializationSectionShowsCubeGroupings() {
+        val state = makeState()
+        val initialState = makeInitialState(state.players)
+        ActivityScenario.launch<GameLogActivity>(intentFor(state, initialState = initialState)).use { scenario ->
+            scenario.onActivity { activity ->
+                val headers = headerTexts(activity)
+                assertTrue("3 cube header should appear", headers.any { it.contains("3 cubes") })
+                assertTrue("2 cube header should appear", headers.any { it.contains("2 cubes") })
+                assertTrue("1 cube header should appear", headers.any { it.contains("1 cube") })
+            }
+        }
+    }
+
+    @Test
+    fun initializationSectionAppearsBeforeEventLog() {
+        val state = stateAfterDraw()
+        val initialState = makeInitialState(state.players)
+        ActivityScenario.launch<GameLogActivity>(intentFor(state, initialState = initialState)).use { scenario ->
+            scenario.onActivity { activity ->
+                val headers = headerTexts(activity)
+                val initIndex = headers.indexOfFirst { it.contains("Initialization") }
+                val eventIndex = headers.indexOfFirst { it.contains("Event 1") }
+                assertTrue("Initialization should come before the event log", initIndex in 0 until eventIndex)
+            }
+        }
+    }
+
     // ── close button ──────────────────────────────────────────────────────────
 
     @Test
@@ -187,11 +259,30 @@ class GameLogActivityTest {
 
     // ── helpers ───────────────────────────────────────────────────────────────
 
-    private fun intentFor(state: TrackableState, seed: Long = 42L): Intent =
+    private fun intentFor(state: TrackableState, seed: Long = 42L, initialState: UntrackableState? = null): Intent =
         Intent(ApplicationProvider.getApplicationContext(), GameLogActivity::class.java).apply {
             putExtra(GameLogActivity.GAME_STATE, state)
             putExtra(GameLogActivity.SEED, seed)
+            initialState?.let { putExtra(GameLogActivity.INITIAL_STATE, it) }
         }
+
+    private fun headerTexts(activity: GameLogActivity): List<String> {
+        val container = activity.findViewById<LinearLayout>(R.id.eventLogContainer)
+        return (0 until container.childCount)
+            .map { container.getChildAt(it) }
+            .filterIsInstance<TextView>()
+            .map { it.text.toString() }
+    }
+
+    private fun makeInitialState(players: List<Player>): UntrackableState {
+        val hands = players.associateWith { cities.take(4).map { c -> CityPlayerCard(c) }.toSet() }
+        val cityStates = mapOf(
+            cities[10] to CityState(mapOf(Color.BLUE to 3)),
+            cities[11] to CityState(mapOf(Color.YELLOW to 2)),
+            cities[12] to CityState(mapOf(Color.BLACK to 1))
+        )
+        return UntrackableState(BoardState(cityStates), hands)
+    }
 
     private fun makeState(
         playerCards: List<PlayerCard> = cities.take(5).map { CityPlayerCard(it) },

--- a/app/src/test/java/gabbard/org/pandemicgenerator/InitialSetupTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/InitialSetupTest.kt
@@ -109,4 +109,19 @@ class InitialSetupTest {
             }
         }
     }
+
+    @Test
+    fun readyToPlayPassesInitialStateToTurnTimer() {
+        // The initial hands/board computed in InitialSetup should be threaded to
+        // TurnTimer so it can eventually reach the Game Log's Initialization section.
+        ActivityScenario.launch<InitialSetup>(intent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<android.view.View>(R.id.button3).performClick()
+                val started = shadowOf(activity).nextStartedActivity
+                @Suppress("DEPRECATION")
+                val initialState = started.getSerializableExtra(TurnTimer.INITIAL_STATE)
+                assertNotNull("INITIAL_STATE should be passed to TurnTimer", initialState)
+            }
+        }
+    }
 }

--- a/app/src/test/java/gabbard/org/pandemicgenerator/NavigationTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/NavigationTest.kt
@@ -6,7 +6,10 @@ import android.view.View
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import org.gabbard.pandemicgenerator.ALL_CITIES
+import org.gabbard.pandemicgenerator.BoardState
 import org.gabbard.pandemicgenerator.CityPlayerCard
+import org.gabbard.pandemicgenerator.CityState
+import org.gabbard.pandemicgenerator.Color
 import org.gabbard.pandemicgenerator.Deck
 import org.gabbard.pandemicgenerator.EventCard
 import org.gabbard.pandemicgenerator.InfectionCard
@@ -17,6 +20,7 @@ import org.gabbard.pandemicgenerator.PlayerCard
 import org.gabbard.pandemicgenerator.Role
 import org.gabbard.pandemicgenerator.TrackableState
 import org.gabbard.pandemicgenerator.Transition
+import org.gabbard.pandemicgenerator.UntrackableState
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -208,13 +212,27 @@ class NavigationTest {
 
     // ── helpers ───────────────────────────────────────────────────────────────
 
-    private fun turnTimerIntent(roleName: String = "Medic"): Intent =
+    private fun turnTimerIntent(roleName: String = "Medic", withInitialState: Boolean = false): Intent =
         Intent(context, TurnTimer::class.java).apply {
             putExtra(TurnTimer.GAME_STATE, makeTrackableState(roleName = roleName))
             putExtra(TurnTimer.RANDOM_SOURCE, Random(42))
             putExtra(TurnTimer.SEED, 42L)
             putExtra(TurnTimer.TURN_DURATION, TurnTimer.NO_TIMER)
+            if (withInitialState) {
+                putExtra(TurnTimer.INITIAL_STATE, makeUntrackableState(roleName = roleName))
+            }
         }
+
+    private fun makeUntrackableState(roleName: String = "Medic"): UntrackableState {
+        val players = listOf(Player(Role(roleName)), Player(Role("Scientist")))
+        val hands = players.associateWith { cities.take(4).map { c -> CityPlayerCard(c) }.toSet() }
+        val cityStates = mapOf(
+            cities[10] to CityState(mapOf(Color.BLUE to 3)),
+            cities[11] to CityState(mapOf(Color.YELLOW to 2)),
+            cities[12] to CityState(mapOf(Color.BLACK to 1))
+        )
+        return UntrackableState(BoardState(cityStates), hands)
+    }
 
     // ── MainActivity resume-game click ────────────────────────────────────────
 
@@ -384,6 +402,88 @@ class NavigationTest {
                 val started = shadowOf(activity).nextStartedActivity
                 @Suppress("DEPRECATION")
                 assertNotNull(started?.getSerializableExtra(GameLogActivity.GAME_STATE))
+            }
+        }
+    }
+
+    // ── INITIAL_STATE threading through the activity chain ─────────────────────
+
+    @Test
+    fun turnTimerForwardsInitialStateToDrawPlayerCards() {
+        ActivityScenario.launch<TurnTimer>(turnTimerIntent(withInitialState = true)).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<View>(R.id.drawPlayerCards).performClick()
+                val started = shadowOf(activity).nextStartedActivity
+                @Suppress("DEPRECATION")
+                assertNotNull(
+                    "INITIAL_STATE should be forwarded to DrawPlayerCards",
+                    started.getSerializableExtra(DrawPlayerCards.INITIAL_STATE)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun drawPlayerCardsForwardsInitialStateToInfectionActivity() {
+        val intent = drawPlayerCardsIntent().apply {
+            putExtra(DrawPlayerCards.INITIAL_STATE, makeUntrackableState())
+        }
+        ActivityScenario.launch<DrawPlayerCards>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<View>(R.id.proceedToInfectionPhase).performClick()
+                val started = shadowOf(activity).nextStartedActivity
+                @Suppress("DEPRECATION")
+                assertNotNull(
+                    "INITIAL_STATE should be forwarded to InfectionActivity",
+                    started.getSerializableExtra(InfectionActivity.INITIAL_STATE)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun infectionActivityForwardsInitialStateToTurnTimer() {
+        val intent = infectionActivityIntent().apply {
+            putExtra(InfectionActivity.INITIAL_STATE, makeUntrackableState())
+        }
+        ActivityScenario.launch<InfectionActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<View>(R.id.nextTurn).performClick()
+                val started = shadowOf(activity).nextStartedActivity
+                @Suppress("DEPRECATION")
+                assertNotNull(
+                    "INITIAL_STATE should be forwarded back to TurnTimer",
+                    started.getSerializableExtra(TurnTimer.INITIAL_STATE)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun viewLogMenuItemFromTurnTimerIncludesInitialStateWhenAvailable() {
+        ActivityScenario.launch<TurnTimer>(turnTimerIntent(withInitialState = true)).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.onOptionsItemSelected(RoboMenuItem(R.id.action_view_log))
+                val started = shadowOf(activity).nextStartedActivity
+                @Suppress("DEPRECATION")
+                assertNotNull(
+                    "INITIAL_STATE should be passed to GameLogActivity when available",
+                    started?.getSerializableExtra(GameLogActivity.INITIAL_STATE)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun viewLogMenuItemOmitsInitialStateWhenUnavailable() {
+        // The default turnTimerIntent() (as used by a resumed saved game) carries no
+        // INITIAL_STATE extra, so the Game Log should simply not receive one either.
+        ActivityScenario.launch<TurnTimer>(turnTimerIntent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.onOptionsItemSelected(RoboMenuItem(R.id.action_view_log))
+                val started = shadowOf(activity).nextStartedActivity
+                @Suppress("DEPRECATION")
+                assertEquals(null, started?.getSerializableExtra(GameLogActivity.INITIAL_STATE))
             }
         }
     }


### PR DESCRIPTION
Fixes #52

## Summary

The Game Log now opens with an "Initialization" section, before the per-event log, showing:
- The game seed (already displayed elsewhere on the screen; now also called out at the top of the log)
- Each player's starting hand
- The initial 9 infection cards drawn to seed the board, grouped by the 3/2/1 cube placements

This data (`UntrackableState`: hands + initial board) is computed once in `InitialSetup.onCreate()` and was previously discarded after being rendered on that screen — only `TrackableState` was kept and threaded onward. `GameLogActivity` had no way to reconstruct it later.

## How it's threaded

Added a new `INITIAL_STATE` Intent extra, following the exact pattern already used for `SEED`/`GAME_STATE`/`RANDOM_SOURCE`:

- `InitialSetup` stores the `UntrackableState` it computes and passes it to `TurnTimer` via `TurnTimer.INITIAL_STATE`.
- `TurnTimer` -> `DrawPlayerCards` -> `InfectionActivity` -> `TurnTimer` each read the extra (nullable, via `as? UntrackableState`) and forward it to the next activity in the chain when present.
- `GameActivity` gained a new `initialStateForLog(): UntrackableState?` hook (alongside the existing `gameStateForLog()`/`seedForLog()`), which each activity overrides. The "View Log" menu action includes the extra only when non-null.
- `GameLogActivity` reads the extra and, when present, renders the Initialization section using the same `addSectionHeader`/`addPlayerCardRow`/`addCityRow` helpers `InitialSetup` already uses, for visual consistency.

When the initial state isn't available (e.g. resuming a saved game via `MainActivity`, which doesn't persist `UntrackableState`), the section is simply omitted — no crash, and log rendering is otherwise unchanged from before.

`UntrackableState`/`Player`/`City`/etc. were already `Serializable`, so this reuses the same `putExtra`/`getSerializableExtra` mechanism already in place for `gameState`.

## Tests

Added/updated hand-written test cases (see limitation below) in:
- `GameLogActivityTest.kt`: Initialization section appears/is omitted correctly, shows starting hands per player, shows cube groupings, and appears before the event log.
- `InitialSetupTest.kt`: `readyToPlay()` passes `INITIAL_STATE` to `TurnTimer`.
- `NavigationTest.kt`: `INITIAL_STATE` forwards correctly through `TurnTimer` -> `DrawPlayerCards` -> `InfectionActivity` -> `TurnTimer`, and is included/omitted correctly when launching `GameLogActivity` via the View Log menu action.

## Limitation

This sandbox has no Android SDK installed, so the `app` module cannot be compiled or have its tests run here. I wrote and reviewed all `app`-module Kotlin changes by hand, closely mirroring the existing style in each file (companion `const val` extras, nullable `as? T` casts, `?.let { }` forwarding, view-binding usage, etc.), and double-checked imports/brace balance. `pandemic-generator-core` is untouched by this change; its existing tests still pass (`gradle :pandemic-generator-core:test`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WeiVDD96CqZ8s67A3txQq5)_