### PR TITLE
Wire up Android SDK for Claude Code on the web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+    exit 0
+fi
+
+ANDROID_SDK_ROOT=/opt/android-sdk
+
+if [ -d "$ANDROID_SDK_ROOT" ]; then
+    echo "sdk.dir=$ANDROID_SDK_ROOT" > "$CLAUDE_PROJECT_DIR/local.properties"
+    {
+        echo "export ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
+        echo "export ANDROID_HOME=$ANDROID_SDK_ROOT"
+        echo "export PATH=\"\$PATH:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin\""
+    } >> "$CLAUDE_ENV_FILE"
+else
+    echo "Android SDK not found at $ANDROID_SDK_ROOT -- see scripts/cloud-environment-setup.sh" \
+        "and set it as this environment's setup script to enable Android builds." >&2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/cloud-environment-setup.sh
+++ b/scripts/cloud-environment-setup.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Setup script for a Claude Code on the web "environment" for this repo.
+#
+# This does NOT run automatically. Paste its contents into the environment's
+# "Setup script" field (open the environment for editing in the web UI).
+# Anthropic snapshots the filesystem after this script succeeds, so the
+# Android SDK it installs is on disk for every future session in that
+# environment -- it does not re-download each time.
+#
+# Also set that environment's network access to "Custom", add
+# dl.google.com to the allowed domains, and check "include defaults" so
+# npm/Maven/etc. still work. The default "Trusted" allowlist does not
+# include dl.google.com, so sdkmanager's downloads would otherwise be
+# blocked.
+#
+# Pairs with .claude/hooks/session-start.sh, which runs every session and
+# wires up local.properties/ANDROID_HOME to the SDK installed here.
+set -euo pipefail
+
+ANDROID_SDK_ROOT=/opt/android-sdk
+CMDLINE_TOOLS_ZIP_URL="https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip"
+# ^ Version number changes over time. Current one confirmed working as of
+# this writing; check https://developer.android.com/studio#command-tools
+# for the latest if this URL starts 404ing.
+
+PLATFORM="platforms;android-34"
+BUILD_TOOLS="build-tools;34.0.0"
+
+mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
+
+if [ ! -x "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" ]; then
+    curl -sSL -o /tmp/cmdline-tools.zip "$CMDLINE_TOOLS_ZIP_URL"
+    unzip -q /tmp/cmdline-tools.zip -d "$ANDROID_SDK_ROOT/cmdline-tools"
+    # the zip unpacks to a "cmdline-tools" subdirectory; sdkmanager expects
+    # it at .../cmdline-tools/latest
+    mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+    rm /tmp/cmdline-tools.zip
+fi
+
+SDKMANAGER="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+
+yes | "$SDKMANAGER" --sdk_root="$ANDROID_SDK_ROOT" --licenses >/dev/null
+"$SDKMANAGER" --sdk_root="$ANDROID_SDK_ROOT" "platform-tools" "$PLATFORM" "$BUILD_TOOLS" >/dev/null
+
+# Make the SDK discoverable by every future session's shell, in case
+# anything besides Gradle needs ANDROID_HOME/ANDROID_SDK_ROOT directly.
+# (Gradle itself is pointed at the SDK via local.properties, written each
+# session by .claude/hooks/session-start.sh, since local.properties is
+# gitignored and won't survive a fresh clone.)
+cat > /etc/profile.d/android-sdk.sh <<EOF
+export ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT
+export ANDROID_HOME=$ANDROID_SDK_ROOT
+export PATH="\$PATH:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin"
+EOF
+
+echo "Android SDK installed at $ANDROID_SDK_ROOT"


### PR DESCRIPTION
## Summary
- The `app` module needs the Android SDK to build, which isn't preinstalled in Claude Code on the web cloud sessions.
- Adds `scripts/cloud-environment-setup.sh`: a one-time install script meant to be pasted into the cloud environment's **Setup script** field (via the web UI, not run automatically). It installs `cmdline-tools`, `platform-tools`, `platforms;android-34`, and `build-tools;34.0.0` to `/opt/android-sdk`. Because Claude Code on the web snapshots the filesystem after a setup script succeeds, this only downloads once — later sessions reuse the cached snapshot.
- Adds `.claude/hooks/session-start.sh` (registered via `.claude/settings.json`): a fast, no-network `SessionStart` hook that runs every session and writes `local.properties` (gitignored, so it doesn't survive a fresh clone) pointing at the SDK installed by the setup script, plus exports `ANDROID_HOME`/`ANDROID_SDK_ROOT`. No-ops locally and when the SDK isn't present yet.

## Manual follow-up (not part of this PR — done in the web UI, not the repo)
After merging, whoever manages the Claude Code on the web environment for this repo should:
1. Open the environment's settings and paste the contents of `scripts/cloud-environment-setup.sh` into the **Setup script** field.
2. Set that environment's **Network access** to **Custom**, add `dl.google.com` to the allowed domains, and check "include default list" (the default Trusted allowlist doesn't include `dl.google.com`, which `sdkmanager` needs).

## Test plan
- [x] Ran `.claude/hooks/session-start.sh` directly with `CLAUDE_CODE_REMOTE=true` and no SDK present — confirmed it no-ops safely (exit 0, no `local.properties` written).
- [x] Ran a copy of the hook pointed at a fake SDK directory — confirmed it writes `local.properties` with the correct `sdk.dir` and exports the expected env vars via `$CLAUDE_ENV_FILE`.
- [x] `./gradlew :pandemic-generator-core:test` (core module, unaffected by this change) still passes.
- [ ] Not verified end-to-end against a real Claude Code on the web environment, since that requires the manual environment-settings step above.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KH3RPuWHg3dbWTZds4exY3


---
_Generated by [Claude Code](https://claude.ai/code/session_01KH3RPuWHg3dbWTZds4exY3)_