### PR TITLE
Swap Event/Epidemic dot colors: green for Epidemic, orange for Event

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/CityDisplay.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/CityDisplay.kt
@@ -63,8 +63,8 @@ fun LinearLayout.addCityRow(city: City, detail: String? = null) =
 
 fun LinearLayout.addPlayerCardRow(card: PlayerCard) = when (card) {
     is CityPlayerCard -> addCityRow(card.city)
-    is EventCard      -> addDotRow(android.graphics.Color.rgb(56, 142, 60), card.name)  // Green 700
-    is Epidemic       -> addDotRow(android.graphics.Color.rgb(183, 28, 28), card.userString)  // Red 900
+    is EventCard      -> addDotRow(android.graphics.Color.rgb(245, 124, 0), card.name)  // Orange 700
+    is Epidemic       -> addDotRow(android.graphics.Color.rgb(56, 142, 60), card.userString)  // Green 700
 }
 
 fun LinearLayout.addSectionHeader(text: String) {


### PR DESCRIPTION
Fixes #69

## Summary

The small colored dot shown next to Event and Epidemic cards in hand listings had the colors backwards from what the issue requests: Event cards were Green 700 and Epidemic cards were Red 900. Per the issue, this swaps them so Epidemic is green and Event is orange.

## Changes

- `app/src/main/java/gabbard/org/pandemicgenerator/CityDisplay.kt`: in `addPlayerCardRow`, `Epidemic` now uses Green 700 (`rgb(56, 142, 60)`, reused from the old `EventCard` branch) and `EventCard` now uses Orange 700 (`rgb(245, 124, 0)`, new). Orange 700 was chosen instead of Amber 700 to stay visually distinct from the Amber 700 / Red 700 / Blue 700 / Grey 800 dot colors already used for city cards in this file.
- Confirmed via grep that `addPlayerCardRow` is used in `InitialSetup.kt` (opening hand listing), `DrawPlayerCards.kt`, and `GameLogActivity.kt` (turn log entries) — all three pick up this color swap automatically since they all funnel through the same function.
- Checked `app/src/test` for any tests asserting on the old RGB values or on `CityDisplay`/`addPlayerCardRow` behavior; none exist, so no test updates were needed.

## Test plan

- [x] `./gradlew :pandemic-generator-core:test` passes (unaffected by this UI-only change; ran via a system-installed Gradle since the wrapper distribution download was blocked in this sandbox).
- [ ] `app` module unit tests and a manual visual check of the dot colors were not run — this environment has no Android SDK configured, so the `app` module can't be built or tested here. The change is a two-line, mechanical color swap reviewed by hand; it should still get a quick visual sanity check (initial setup screen and game log) on a device/emulator before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X1Qh7f8y9nH3VZSUECduZF)_