### PR TITLE
Add turn timer checkbox to custom rule set editor

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/EditRuleSetActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/EditRuleSetActivity.kt
@@ -40,6 +40,12 @@ class EditRuleSetActivity : AppCompatActivity() {
                 if (checkedId == R.id.epidemic_named) android.view.View.VISIBLE else android.view.View.GONE
         }
 
+        // Toggle turn duration field visibility with the "Use a timer" checkbox
+        binding.useTimer.setOnCheckedChangeListener { _, isChecked ->
+            binding.turnDurationSeconds.visibility =
+                if (isChecked) android.view.View.VISIBLE else android.view.View.GONE
+        }
+
         // Pre-populate event checkboxes, excluding events that require infection deck interaction
         val sortedEvents = MULTI_BOARD_COMPATIBLE_EVENTS.sortedBy { it.name }
         val eventCheckBoxes = mutableMapOf<EventCard, CheckBox>()
@@ -121,6 +127,12 @@ class EditRuleSetActivity : AppCompatActivity() {
 
         for ((role, cb) in roleCheckBoxes) {
             cb.isChecked = role in ruleSet.availableRoles
+        }
+
+        val turnDurationSeconds = ruleSet.turnDurationSeconds
+        if (turnDurationSeconds != null) {
+            binding.useTimer.isChecked = true
+            binding.turnDurationSeconds.setText(turnDurationSeconds.toString())
         }
     }
 
@@ -240,6 +252,17 @@ class EditRuleSetActivity : AppCompatActivity() {
             return null
         }
 
+        val turnDurationSeconds: Int? = if (binding.useTimer.isChecked) {
+            val duration = binding.turnDurationSeconds.text.toString().toIntOrNull()
+            if (duration == null || duration < 1) {
+                Toast.makeText(this, "Enter a valid turn duration in seconds", Toast.LENGTH_SHORT).show()
+                return null
+            }
+            duration
+        } else {
+            null
+        }
+
         return RuleSet(
             name = name,
             availableRoles = availableRoles,
@@ -247,7 +270,8 @@ class EditRuleSetActivity : AppCompatActivity() {
             availableEvents = availableEvents,
             numEventsToUse = numEventsToUse,
             availableDifficulties = difficulties,
-            allowedPlayerCounts = allowedPlayerCounts
+            allowedPlayerCounts = allowedPlayerCounts,
+            turnDurationSeconds = turnDurationSeconds
         )
     }
 

--- a/app/src/main/res/layout/activity_edit_ruleset.xml
+++ b/app/src/main/res/layout/activity_edit_ruleset.xml
@@ -185,6 +185,40 @@
             android:layout_marginTop="4dp"
             android:layout_marginBottom="16dp" />
 
+        <!-- Turn Timer -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Turn Timer"
+            android:textStyle="bold"
+            android:textSize="16sp"
+            android:layout_marginBottom="4dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="16dp">
+
+            <CheckBox
+                android:id="@+id/use_timer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Use a timer" />
+
+            <EditText
+                android:id="@+id/turn_duration_seconds"
+                android:layout_width="64dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:hint="Seconds"
+                android:inputType="number"
+                android:text="75"
+                android:visibility="gone" />
+
+        </LinearLayout>
+
         <Button
             android:id="@+id/save_button"
             android:layout_width="match_parent"

--- a/app/src/test/java/gabbard/org/pandemicgenerator/EditRuleSetActivityTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/EditRuleSetActivityTest.kt
@@ -389,4 +389,136 @@ class EditRuleSetActivityTest {
             }
         }
     }
+
+    // ── Turn timer ────────────────────────────────────────────────────────────
+
+    @Test
+    fun newRuleSetHasTimerUncheckedAndFieldHiddenByDefault() {
+        ActivityScenario.launch<EditRuleSetActivity>(newIntent()).use { scenario ->
+            scenario.onActivity { activity ->
+                assertFalse(activity.findViewById<CheckBox>(R.id.use_timer).isChecked)
+                assertEquals(
+                    View.GONE,
+                    activity.findViewById<View>(R.id.turn_duration_seconds).visibility
+                )
+            }
+        }
+    }
+
+    @Test
+    fun checkingUseTimerRevealsDurationField() {
+        ActivityScenario.launch<EditRuleSetActivity>(newIntent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<CheckBox>(R.id.use_timer).isChecked = true
+                assertEquals(
+                    View.VISIBLE,
+                    activity.findViewById<View>(R.id.turn_duration_seconds).visibility
+                )
+            }
+        }
+    }
+
+    @Test
+    fun saveWithoutTimerLeavesTurnDurationSecondsNull() {
+        ActivityScenario.launch<EditRuleSetActivity>(newIntent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<EditText>(R.id.ruleset_name).setText("No Timer Rule Set")
+                checkAllRoles(activity)
+                activity.findViewById<EditText>(R.id.num_events_to_use).setText("0")
+                activity.findViewById<View>(R.id.save_button).performClick()
+                val saved = RuleSetRepository.load(context)
+                assertEquals(1, saved.size)
+                assertEquals(null, saved[0].turnDurationSeconds)
+            }
+        }
+    }
+
+    @Test
+    fun saveWithTimerCheckedAndValidDurationPersistsDuration() {
+        ActivityScenario.launch<EditRuleSetActivity>(newIntent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<EditText>(R.id.ruleset_name).setText("Timed Rule Set")
+                activity.findViewById<CheckBox>(R.id.use_timer).isChecked = true
+                activity.findViewById<EditText>(R.id.turn_duration_seconds).setText("90")
+                checkAllRoles(activity)
+                activity.findViewById<EditText>(R.id.num_events_to_use).setText("0")
+                activity.findViewById<View>(R.id.save_button).performClick()
+                assertTrue("Activity should finish after a valid timed save", activity.isFinishing)
+                val saved = RuleSetRepository.load(context)
+                assertEquals(1, saved.size)
+                assertEquals(90, saved[0].turnDurationSeconds)
+            }
+        }
+    }
+
+    @Test
+    fun saveWithTimerCheckedAndEmptyDurationDoesNotSave() {
+        ActivityScenario.launch<EditRuleSetActivity>(newIntent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<EditText>(R.id.ruleset_name).setText("Invalid Timer Rule Set")
+                activity.findViewById<CheckBox>(R.id.use_timer).isChecked = true
+                activity.findViewById<EditText>(R.id.turn_duration_seconds).setText("")
+                checkAllRoles(activity)
+                activity.findViewById<EditText>(R.id.num_events_to_use).setText("0")
+                activity.findViewById<View>(R.id.save_button).performClick()
+                assertFalse(
+                    "Activity should not finish when timer is checked with an empty duration",
+                    activity.isFinishing
+                )
+            }
+        }
+    }
+
+    @Test
+    fun saveWithTimerCheckedAndNonPositiveDurationDoesNotSave() {
+        ActivityScenario.launch<EditRuleSetActivity>(newIntent()).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.findViewById<EditText>(R.id.ruleset_name).setText("Zero Timer Rule Set")
+                activity.findViewById<CheckBox>(R.id.use_timer).isChecked = true
+                activity.findViewById<EditText>(R.id.turn_duration_seconds).setText("0")
+                checkAllRoles(activity)
+                activity.findViewById<EditText>(R.id.num_events_to_use).setText("0")
+                activity.findViewById<View>(R.id.save_button).performClick()
+                assertFalse(
+                    "Activity should not finish when timer duration is not positive",
+                    activity.isFinishing
+                )
+            }
+        }
+    }
+
+    @Test
+    fun existingRuleSetWithTimerPopulatesCheckboxAndDuration() {
+        // NATIONAL_CHAMPIONSHIP has turnDurationSeconds = 75
+        ActivityScenario.launch<EditRuleSetActivity>(editIntent()).use { scenario ->
+            scenario.onActivity { activity ->
+                assertTrue(
+                    "use_timer should be checked for a rule set with a non-null turnDurationSeconds",
+                    activity.findViewById<CheckBox>(R.id.use_timer).isChecked
+                )
+                assertEquals(
+                    "75",
+                    activity.findViewById<EditText>(R.id.turn_duration_seconds).text.toString()
+                )
+                assertEquals(
+                    View.VISIBLE,
+                    activity.findViewById<View>(R.id.turn_duration_seconds).visibility
+                )
+            }
+        }
+    }
+
+    @Test
+    fun existingRuleSetWithoutTimerLeavesCheckboxUnchecked() {
+        val ruleSet = NATIONAL_CHAMPIONSHIP.copy(turnDurationSeconds = null)
+        ActivityScenario.launch<EditRuleSetActivity>(editIntent(ruleSet = ruleSet)).use { scenario ->
+            scenario.onActivity { activity ->
+                assertFalse(activity.findViewById<CheckBox>(R.id.use_timer).isChecked)
+                assertEquals(
+                    View.GONE,
+                    activity.findViewById<View>(R.id.turn_duration_seconds).visibility
+                )
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes #68

## Summary

`RuleSet.turnDurationSeconds` already existed (`null` = no timer, positive `Int` = turn duration in seconds) and was already wired through end-to-end at runtime — `InitialSetup.kt` reads `gameRules!!.turnDurationSeconds ?: -1` and forwards it to `TurnTimer`, and `NATIONAL_CHAMPIONSHIP`/`NATIONAL_CHAMPIONSHIP_RULES` already set it to `75`. The only missing piece was a way to set this field when creating or editing a **custom** rule set — the editor UI (`EditRuleSetActivity` / `activity_edit_ruleset.xml`) never exposed it, so every custom rule set silently defaulted to no timer.

## Changes

- **`activity_edit_ruleset.xml`** — added a "Turn Timer" section, following the same bold-header + row layout used elsewhere on the screen (e.g. the "Number of events to include per game" row): a `use_timer` checkbox plus a `turn_duration_seconds` numeric `EditText` (hint "Seconds", pre-filled with `75` to match the existing `NATIONAL_CHAMPIONSHIP` example), hidden by default until the checkbox is checked.
- **`EditRuleSetActivity.kt`**:
  - Wired a checked-change listener on `use_timer` that toggles the visibility of `turn_duration_seconds`, mirroring the existing `epidemicTypeGroup` → `namedEpidemicsContainer` pattern.
  - `buildRuleSet()` now validates the duration when the checkbox is checked (must parse to a positive `Int`), showing a `Toast` and aborting the save on invalid input — following the same validation-and-`Toast`-and-`return null` pattern used for the other fields in this method. When unchecked, `turnDurationSeconds` is `null`.
  - `populateFromRuleSet()` now checks the box and pre-fills the field when editing a rule set whose `turnDurationSeconds` is non-null (e.g. `NATIONAL_CHAMPIONSHIP`).
- **`EditRuleSetActivityTest.kt`** — added Robolectric cases covering: default unchecked/hidden state on a new rule set; checking the box reveals the field; saving unchecked leaves `turnDurationSeconds` null; saving checked with a valid duration persists it; saving checked with an empty or non-positive duration is rejected and the activity doesn't finish; and editing an existing rule set with/without a timer correctly restores the checkbox and field state.

## Test plan

- [x] `./gradlew :pandemic-generator-core:test` passes (this change doesn't touch the core module's logic — `RuleSet.turnDurationSeconds` already existed there — but confirming it stays green regardless). Ran via a system-installed Gradle since the wrapper's distribution download was blocked in this sandbox.
- [ ] `app` module unit tests (including the new `EditRuleSetActivityTest` cases) were **not** run — this environment has no Android SDK configured (`ANDROID_HOME`/`local.properties` `sdk.dir` unset), so the `app` module can't be built or tested here. The XML and Kotlin changes were written and reviewed carefully by hand against the existing patterns in the same files, and the new tests follow the existing Robolectric harness/style already used in `EditRuleSetActivityTest.kt`. Should be sanity-checked by running `./gradlew :app:testDebugUnitTest` and a manual walkthrough of creating/editing a custom rule set on a device/emulator before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1Qh7f8y9nH3VZSUECduZF)_