### PR TITLE
Add GenCon 2026 rule set

### DIFF
--- a/app/src/test/java/gabbard/org/pandemicgenerator/RuleSetSelectionActivityTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/RuleSetSelectionActivityTest.kt
@@ -102,8 +102,8 @@ class RuleSetSelectionActivityTest {
         ActivityScenario.launch(RuleSetSelectionActivity::class.java).use { scenario ->
             scenario.onActivity { activity ->
                 val container = activity.findViewById<LinearLayout>(R.id.rule_sets_container)
-                // 2 built-in + 1 custom
-                assertEquals(3, container.childCount)
+                // built-in rows + 1 custom
+                assertEquals(BUILT_IN_RULE_SETS.size + 1, container.childCount)
             }
         }
     }
@@ -114,8 +114,8 @@ class RuleSetSelectionActivityTest {
         ActivityScenario.launch(RuleSetSelectionActivity::class.java).use { scenario ->
             scenario.onActivity { activity ->
                 val container = activity.findViewById<LinearLayout>(R.id.rule_sets_container)
-                // Custom row is at index 2 (after the 2 built-in rows)
-                val customRow = container.getChildAt(2) as LinearLayout
+                // Custom row is after the built-in rows
+                val customRow = container.getChildAt(BUILT_IN_RULE_SETS.size) as LinearLayout
                 val buttonTexts = (0 until customRow.childCount)
                     .map { customRow.getChildAt(it) }
                     .filterIsInstance<Button>()
@@ -134,7 +134,7 @@ class RuleSetSelectionActivityTest {
         ActivityScenario.launch(RuleSetSelectionActivity::class.java).use { scenario ->
             scenario.onActivity { activity ->
                 val container = activity.findViewById<LinearLayout>(R.id.rule_sets_container)
-                val customRow = container.getChildAt(2) as LinearLayout
+                val customRow = container.getChildAt(BUILT_IN_RULE_SETS.size) as LinearLayout
                 // Children: TextView(0), Select(1), Edit(2), Delete(3)
                 val editButton = customRow.getChildAt(2) as Button
                 editButton.performClick()
@@ -151,7 +151,7 @@ class RuleSetSelectionActivityTest {
             scenario.onActivity { activity ->
                 val container = activity.findViewById<LinearLayout>(R.id.rule_sets_container)
                 val countBefore = container.childCount
-                val customRow = container.getChildAt(2) as LinearLayout
+                val customRow = container.getChildAt(BUILT_IN_RULE_SETS.size) as LinearLayout
                 // Children: TextView(0), Select(1), Edit(2), Delete(3)
                 val deleteButton = customRow.getChildAt(3) as Button
                 deleteButton.performClick()
@@ -168,7 +168,7 @@ class RuleSetSelectionActivityTest {
         ActivityScenario.launch(RuleSetSelectionActivity::class.java).use { scenario ->
             scenario.onActivity { activity ->
                 val container = activity.findViewById<LinearLayout>(R.id.rule_sets_container)
-                val customRow = container.getChildAt(2) as LinearLayout
+                val customRow = container.getChildAt(BUILT_IN_RULE_SETS.size) as LinearLayout
                 // Children: TextView (index 0), Button "Select" (index 1), Button "Edit" (index 2), Button "Delete" (index 3)
                 val selectButton = customRow.getChildAt(1) as Button
                 selectButton.performClick()

--- a/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/RuleSet.kt
+++ b/pandemic-generator-core/src/main/java/org/gabbard/pandemicgenerator/RuleSet.kt
@@ -65,7 +65,23 @@ val STANDARD_PANDEMIC = RuleSet(
     allowedPlayerCounts = listOf(2, 3, 4)
 )
 
-val BUILT_IN_RULE_SETS: List<RuleSet> = listOf(STANDARD_PANDEMIC, NATIONAL_CHAMPIONSHIP)
+val GENCON_2026 = RuleSet(
+    name = "GenCon 2026",
+    availableRoles = COMPETITIVE_PLAY_ROLES,
+    availableEpidemics = STANDARD_PANDEMIC_EPIDEMICS,
+    availableEvents = ALL_KNOWN_EVENTS,
+    numEventsToUse = ALL_KNOWN_EVENTS.size,
+    availableDifficulties = listOf(
+        Difficulty("Introductory", 4),
+        Difficulty("Normal", 5),
+        Difficulty("Heroic", 6)
+    ),
+    allowedPlayerCounts = listOf(2, 3, 4),
+    turnDurationSeconds = 75
+)
+
+val BUILT_IN_RULE_SETS: List<RuleSet> =
+    listOf(STANDARD_PANDEMIC, NATIONAL_CHAMPIONSHIP, GENCON_2026)
 
 // backward-compatible name used by CLI and tests
 val NATIONAL_CHAMPIONSHIP_RULES: GameRules = NATIONAL_CHAMPIONSHIP.buildGameRules(

--- a/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/RuleSetTest.kt
+++ b/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/RuleSetTest.kt
@@ -170,12 +170,59 @@ class RuleSetTest {
         assertEquals(6, rules.numEpidemicsToUse)
     }
 
+    // ── GENCON_2026 configuration ─────────────────────────────────────────────
+
+    @Test
+    fun genCon2026Allows2To4Players() {
+        assertEquals(listOf(2, 3, 4), GENCON_2026.allowedPlayerCounts)
+    }
+
+    @Test
+    fun genCon2026TurnDurationIs75Seconds() {
+        assertEquals(75, GENCON_2026.turnDurationSeconds)
+    }
+
+    @Test
+    fun genCon2026UsesSimpleEpidemics() {
+        assertTrue(GENCON_2026.availableEpidemics.all { it is SimpleEpidemic })
+    }
+
+    @Test
+    fun genCon2026IntroductoryHasFourEpidemics() {
+        val rules = GENCON_2026.buildGameRules(GameOptions(2, Difficulty("Introductory", 4)))
+        assertEquals(4, rules.numEpidemicsToUse)
+    }
+
+    @Test
+    fun genCon2026NormalHasFiveEpidemics() {
+        val rules = GENCON_2026.buildGameRules(GameOptions(2, Difficulty("Normal", 5)))
+        assertEquals(5, rules.numEpidemicsToUse)
+    }
+
+    @Test
+    fun genCon2026HeroicHasSixEpidemics() {
+        val rules = GENCON_2026.buildGameRules(GameOptions(2, Difficulty("Heroic", 6)))
+        assertEquals(6, rules.numEpidemicsToUse)
+    }
+
+    @Test
+    fun genCon2026UsesAllCurrentlyAvailableRoles() {
+        assertEquals(ALL_ROLES - INFECTION_DECK_INTERACTION_ROLES, GENCON_2026.availableRoles)
+    }
+
+    @Test
+    fun genCon2026UsesAllCurrentlyAvailableEvents() {
+        assertEquals(ALL_KNOWN_EVENTS, GENCON_2026.availableEvents)
+        assertEquals(ALL_KNOWN_EVENTS.size, GENCON_2026.numEventsToUse)
+    }
+
     // ── BUILT_IN_RULE_SETS ────────────────────────────────────────────────────
 
     @Test
-    fun builtInRuleSetsContainsBothVariants() {
+    fun builtInRuleSetsContainsAllVariants() {
         assertTrue(BUILT_IN_RULE_SETS.contains(STANDARD_PANDEMIC))
         assertTrue(BUILT_IN_RULE_SETS.contains(NATIONAL_CHAMPIONSHIP))
+        assertTrue(BUILT_IN_RULE_SETS.contains(GENCON_2026))
     }
 
     // ── turn order across a full game (regression test for #55) ─────────────


### PR DESCRIPTION
## Summary

- Adds a new built-in `GENCON_2026` rule set: 2-4 players, Simple Epidemic cards, Introductory (4) / Normal (5) / Heroic (6) difficulty tiers, a 75-second turn timer, and all currently implemented roles and events (rather than a randomly-chosen subset).
- Registers it in `BUILT_IN_RULE_SETS` alongside `STANDARD_PANDEMIC` and `NATIONAL_CHAMPIONSHIP`.

## Test plan

- [x] Added unit tests in `RuleSetTest.kt` covering allowed player counts, turn duration, epidemic type, difficulty tiers, and that all currently available roles/events are used.
- [x] `./gradlew :pandemic-generator-core:test` passes.

Closes #73

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWFRMhY1BcvHE8UaFmTR1B)_