### PR TITLE
Distinguish draw/infection phases and separate turns in game log

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/CityDisplay.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/CityDisplay.kt
@@ -68,6 +68,19 @@ fun LinearLayout.addPlayerCardRow(card: PlayerCard) = when (card) {
     is Epidemic       -> addDotRow(android.graphics.Color.rgb(56, 142, 60), card.userString)  // Green 700
 }
 
+fun LinearLayout.addDivider() {
+    val dp = context.resources.displayMetrics.density
+    addView(
+        View(context).apply {
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                (1 * dp).toInt()
+            ).also { it.topMargin = (16 * dp).toInt() }
+            setBackgroundColor(android.graphics.Color.LTGRAY)
+        }
+    )
+}
+
 fun LinearLayout.addSectionHeader(text: String) {
     val dp = context.resources.displayMetrics.density
     addView(TextView(context).apply {

--- a/app/src/main/java/gabbard/org/pandemicgenerator/CityDisplay.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/CityDisplay.kt
@@ -68,10 +68,13 @@ fun LinearLayout.addPlayerCardRow(card: PlayerCard) = when (card) {
     is Epidemic       -> addDotRow(android.graphics.Color.rgb(56, 142, 60), card.userString)  // Green 700
 }
 
+const val TURN_DIVIDER_TAG = "turn_divider"
+
 fun LinearLayout.addDivider() {
     val dp = context.resources.displayMetrics.density
     addView(
         View(context).apply {
+            tag = TURN_DIVIDER_TAG
             layoutParams = LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
                 (1 * dp).toInt()

--- a/app/src/main/java/gabbard/org/pandemicgenerator/GameLogActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/GameLogActivity.kt
@@ -66,12 +66,16 @@ class GameLogActivity : AppCompatActivity() {
             var isFirstEpidemicOfGame = true
             log.forEach { event ->
                 if (event is GameEvent.DrawPlayerCardsEvent || event.player != lastPlayer) {
+                    if (turnNumber > 0) {
+                        container.addDivider()
+                    }
                     turnNumber++
                     container.addSectionHeader("Turn $turnNumber — ${event.player.role.name}")
                 }
                 lastPlayer = event.player
                 when (event) {
                     is GameEvent.DrawPlayerCardsEvent -> {
+                        container.addSectionHeader("Draw phase")
                         event.cardsDrawn.forEach { container.addPlayerCardRow(it) }
                         for ((epidemic, city) in event.epidemicsAndInfectedCities) {
                             container.addSectionHeader("Epidemic: ${epidemic.userString}")
@@ -83,6 +87,7 @@ class GameLogActivity : AppCompatActivity() {
                         }
                     }
                     is GameEvent.InfectionEvent -> {
+                        container.addSectionHeader("Infection phase")
                         event.infectedCities.forEach { container.addCityRow(it) }
                     }
                 }

--- a/app/src/test/java/gabbard/org/pandemicgenerator/GameLogActivityTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/GameLogActivityTest.kt
@@ -161,10 +161,10 @@ class GameLogActivityTest {
             scenario.onActivity { activity ->
                 val container = activity.findViewById<LinearLayout>(R.id.eventLogContainer)
                 val children = (0 until container.childCount).map { container.getChildAt(it) }
-                val dividerCount = children.count { it !is TextView }
+                val dividerCount = children.count { it.tag == TURN_DIVIDER_TAG }
                 assertEquals("There should be exactly one divider, between the two turns", 1, dividerCount)
 
-                val firstHeaderIndex = children.indexOfFirst { it is TextView && (it as TextView).text.contains("Turn 1") }
+                val firstHeaderIndex = children.indexOfFirst { it is TextView && it.text.contains("Turn 1") }
                 assertEquals("Nothing should precede the first turn's header", 0, firstHeaderIndex)
             }
         }

--- a/app/src/test/java/gabbard/org/pandemicgenerator/GameLogActivityTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/GameLogActivityTest.kt
@@ -131,6 +131,46 @@ class GameLogActivityTest {
     }
 
     @Test
+    fun drawAndInfectionPhasesAreLabeledSeparately() {
+        val afterDraw = stateAfterDraw()
+        val afterInfect = stateAfterInfect(afterDraw)
+
+        ActivityScenario.launch<GameLogActivity>(intentFor(afterInfect)).use { scenario ->
+            scenario.onActivity { activity ->
+                val headers = headerTexts(activity)
+                assertTrue("Draw phase header should appear", headers.any { it.contains("Draw phase") })
+                assertTrue("Infection phase header should appear", headers.any { it.contains("Infection phase") })
+                assertTrue(
+                    "Draw phase should come before Infection phase",
+                    headers.indexOfFirst { it.contains("Draw phase") } <
+                        headers.indexOfFirst { it.contains("Infection phase") }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun dividerSeparatesTurnsButNotFirstTurn() {
+        val afterFirstDraw = stateAfterDraw()
+        val afterFirstInfect = stateAfterInfect(afterFirstDraw)
+        val afterSecondDraw = (afterFirstInfect.executeTransition(Transition.DRAW_PLAYER_CARDS, rng)
+                as TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult)
+            .newGameState
+
+        ActivityScenario.launch<GameLogActivity>(intentFor(afterSecondDraw)).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = activity.findViewById<LinearLayout>(R.id.eventLogContainer)
+                val children = (0 until container.childCount).map { container.getChildAt(it) }
+                val dividerCount = children.count { it !is TextView }
+                assertEquals("There should be exactly one divider, between the two turns", 1, dividerCount)
+
+                val firstHeaderIndex = children.indexOfFirst { it is TextView && (it as TextView).text.contains("Turn 1") }
+                assertEquals("Nothing should precede the first turn's header", 0, firstHeaderIndex)
+            }
+        }
+    }
+
+    @Test
     fun secondPlayersTurnGetsItsOwnHeader() {
         // Simulate a full round: player 0 draws + infects, then player 1 draws.
         val afterFirstDraw = stateAfterDraw()


### PR DESCRIPTION
## Summary
- Each turn's game log section now labels its "Draw phase" and "Infection phase" separately instead of showing draw and infection events undifferentiated under one turn header.
- A divider line is now drawn between turns so everything belonging to a single turn is visually grouped together (no divider before the first turn's header, since there's nothing to separate it from).

Fixes #74

## Test plan
- [x] `./gradlew :pandemic-generator-core:test` (unaffected by this change, passes)
- [x] Added `drawAndInfectionPhasesAreLabeledSeparately` and `dividerSeparatesTurnsButNotFirstTurn` to `GameLogActivityTest`
- [ ] `./gradlew :app:testDebugUnitTest` — not run; no Android SDK available in this sandbox. Traced existing assertions by hand against the new output; none depend on child positions/counts affected by the new headers/divider.

---
_Generated by [Claude Code](https://claude.ai/code/session_0133DKFdzuJ8zPcqRkwTWpao)_