### PR TITLE
Only show Virulent Strain explanation when it's actually in play

### DIFF
--- a/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/DrawPlayerCards.kt
@@ -6,6 +6,8 @@ import android.view.View
 import gabbard.org.pandemicgenerator.databinding.ActivityDrawPlayerCardsBinding
 import org.gabbard.pandemicgenerator.Epidemic
 import org.gabbard.pandemicgenerator.City
+import org.gabbard.pandemicgenerator.GameEvent
+import org.gabbard.pandemicgenerator.NamedEpidemic
 import org.gabbard.pandemicgenerator.PlayerCard
 import org.gabbard.pandemicgenerator.TrackableState
 import org.gabbard.pandemicgenerator.Transition
@@ -21,6 +23,7 @@ class DrawPlayerCards : GameActivity() {
     private var cardsDrawn: List<PlayerCard> = emptyList()
     private var epidemicsAndInfectedCities: List<Pair<Epidemic, City>> = emptyList()
     private var initialState: UntrackableState? = null
+    private var firstVirulentStrainEpidemicIndex: Int = -1
 
     companion object {
         const val GAME_STATE = "game_state"
@@ -32,6 +35,8 @@ class DrawPlayerCards : GameActivity() {
         private const val RESULT_GAME_STATE = "result_game_state"
         private const val RESULT_CARDS_DRAWN = "result_cards_drawn"
         private const val RESULT_EPIDEMICS_AND_INFECTED_CITIES = "result_epidemics_and_infected_cities"
+        private const val RESULT_FIRST_VIRULENT_STRAIN_EPIDEMIC_INDEX =
+            "result_first_virulent_strain_epidemic_index"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -60,9 +65,18 @@ class DrawPlayerCards : GameActivity() {
                     return
                 }
                 is TrackableState.TransitionResult.Success.DrawPlayerCardsTransitionResult -> {
+                    val virulentStrainAlreadyDetermined = gameState!!.eventLog.any { event ->
+                        event is GameEvent.DrawPlayerCardsEvent &&
+                            event.epidemicsAndInfectedCities.any { it.first is NamedEpidemic }
+                    }
                     gameState = result.newGameState
                     cardsDrawn = result.cardsDrawn
                     epidemicsAndInfectedCities = result.epidemicsAndInfectedCities
+                    firstVirulentStrainEpidemicIndex = if (virulentStrainAlreadyDetermined) {
+                        -1
+                    } else {
+                        epidemicsAndInfectedCities.indexOfFirst { it.first is NamedEpidemic }
+                    }
                 }
                 else -> error("Unexpected result type for DRAW_PLAYER_CARDS: $result")
             }
@@ -80,15 +94,20 @@ class DrawPlayerCards : GameActivity() {
             epidemicsAndInfectedCities = savedInstanceState.getSerializable(
                 RESULT_EPIDEMICS_AND_INFECTED_CITIES
             ) as List<Pair<Epidemic, City>>
+            firstVirulentStrainEpidemicIndex =
+                savedInstanceState.getInt(RESULT_FIRST_VIRULENT_STRAIN_EPIDEMIC_INDEX)
         }
 
         val container = binding.cardsContainer
         container.addSectionHeader("Cards drawn:")
         cardsDrawn.forEach { container.addPlayerCardRow(it) }
 
-        for ((epidemic, city) in epidemicsAndInfectedCities) {
+        epidemicsAndInfectedCities.forEachIndexed { index, (epidemic, city) ->
             container.addSectionHeader("Epidemic: ${epidemic.userString}")
             container.addCityRow(city, "infected from bottom")
+            if (index == firstVirulentStrainEpidemicIndex) {
+                container.addFirstEpidemicVirulentStrainExplanation(seed)
+            }
         }
     }
 
@@ -99,6 +118,7 @@ class DrawPlayerCards : GameActivity() {
             outState.putSerializable(RESULT_GAME_STATE, gameState)
             outState.putSerializable(RESULT_CARDS_DRAWN, ArrayList(cardsDrawn))
             outState.putSerializable(RESULT_EPIDEMICS_AND_INFECTED_CITIES, ArrayList(epidemicsAndInfectedCities))
+            outState.putInt(RESULT_FIRST_VIRULENT_STRAIN_EPIDEMIC_INDEX, firstVirulentStrainEpidemicIndex)
         }
     }
 

--- a/app/src/main/java/gabbard/org/pandemicgenerator/GameLogActivity.kt
+++ b/app/src/main/java/gabbard/org/pandemicgenerator/GameLogActivity.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import gabbard.org.pandemicgenerator.databinding.ActivityGameLogBinding
 import org.gabbard.pandemicgenerator.GameEvent
+import org.gabbard.pandemicgenerator.NamedEpidemic
 import org.gabbard.pandemicgenerator.Player
 import org.gabbard.pandemicgenerator.TrackableState
 import org.gabbard.pandemicgenerator.UntrackableState
@@ -63,7 +64,7 @@ class GameLogActivity : AppCompatActivity() {
             // that follows it are shown together under a single "Turn N — <Player>" header.
             var turnNumber = 0
             var lastPlayer: Player? = null
-            var isFirstEpidemicOfGame = true
+            var virulentStrainDetermined = false
             log.forEach { event ->
                 if (event is GameEvent.DrawPlayerCardsEvent || event.player != lastPlayer) {
                     turnNumber++
@@ -76,9 +77,9 @@ class GameLogActivity : AppCompatActivity() {
                         for ((epidemic, city) in event.epidemicsAndInfectedCities) {
                             container.addSectionHeader("Epidemic: ${epidemic.userString}")
                             container.addCityRow(city, "infected from bottom")
-                            if (isFirstEpidemicOfGame) {
+                            if (epidemic is NamedEpidemic && !virulentStrainDetermined) {
                                 container.addFirstEpidemicVirulentStrainExplanation(seed)
-                                isFirstEpidemicOfGame = false
+                                virulentStrainDetermined = true
                             }
                         }
                     }

--- a/app/src/test/java/gabbard/org/pandemicgenerator/GameLogActivityTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/GameLogActivityTest.kt
@@ -19,6 +19,7 @@ import org.gabbard.pandemicgenerator.NamedEpidemic
 import org.gabbard.pandemicgenerator.Player
 import org.gabbard.pandemicgenerator.PlayerCard
 import org.gabbard.pandemicgenerator.Role
+import org.gabbard.pandemicgenerator.SimpleEpidemic
 import org.gabbard.pandemicgenerator.TrackableState
 import org.gabbard.pandemicgenerator.Transition
 import org.gabbard.pandemicgenerator.UntrackableState
@@ -173,6 +174,71 @@ class GameLogActivityTest {
                     .filterIsInstance<TextView>()
                     .map { it.text.toString() }
                 assertTrue("Epidemic section should appear in log", headers.any { it.contains("Epidemic") })
+            }
+        }
+    }
+
+    @Test
+    fun drawPlayerCardsEventWithNamedEpidemicShowsVirulentStrainExplanation() {
+        val epidemic = NamedEpidemic("Virulent")
+        val city = cities[0]
+        val event = GameEvent.DrawPlayerCardsEvent(
+            cardsDrawn = listOf(epidemic, CityPlayerCard(cities[1])),
+            epidemicsAndInfectedCities = listOf(epidemic to city),
+            player = Player(Role("Medic"))
+        )
+        val state = makeState(eventLog = listOf(event))
+        ActivityScenario.launch<GameLogActivity>(intentFor(state)).use { scenario ->
+            scenario.onActivity { activity ->
+                val headers = headerTexts(activity)
+                assertTrue(
+                    "Virulent Strain explanation should appear",
+                    headers.any { it.contains("Virulent Strain determination") }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun drawPlayerCardsEventWithSimpleEpidemicDoesNotShowVirulentStrainExplanation() {
+        val epidemic = SimpleEpidemic()
+        val city = cities[0]
+        val event = GameEvent.DrawPlayerCardsEvent(
+            cardsDrawn = listOf(epidemic, CityPlayerCard(cities[1])),
+            epidemicsAndInfectedCities = listOf(epidemic to city),
+            player = Player(Role("Medic"))
+        )
+        val state = makeState(eventLog = listOf(event))
+        ActivityScenario.launch<GameLogActivity>(intentFor(state)).use { scenario ->
+            scenario.onActivity { activity ->
+                val headers = headerTexts(activity)
+                assertTrue(
+                    "Virulent Strain explanation should not appear for a Simple epidemic",
+                    headers.none { it.contains("Virulent Strain determination") }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun virulentStrainExplanationOnlyShownOnceAcrossMultipleNamedEpidemics() {
+        val firstEpidemic = NamedEpidemic("First")
+        val secondEpidemic = NamedEpidemic("Second")
+        val firstEvent = GameEvent.DrawPlayerCardsEvent(
+            cardsDrawn = listOf(firstEpidemic),
+            epidemicsAndInfectedCities = listOf(firstEpidemic to cities[0]),
+            player = Player(Role("Medic"))
+        )
+        val secondEvent = GameEvent.DrawPlayerCardsEvent(
+            cardsDrawn = listOf(secondEpidemic),
+            epidemicsAndInfectedCities = listOf(secondEpidemic to cities[1]),
+            player = Player(Role("Scientist"))
+        )
+        val state = makeState(eventLog = listOf(firstEvent, secondEvent))
+        ActivityScenario.launch<GameLogActivity>(intentFor(state)).use { scenario ->
+            scenario.onActivity { activity ->
+                val headers = headerTexts(activity)
+                assertEquals(1, headers.count { it.contains("Virulent Strain determination") })
             }
         }
     }

--- a/app/src/test/java/gabbard/org/pandemicgenerator/NavigationTest.kt
+++ b/app/src/test/java/gabbard/org/pandemicgenerator/NavigationTest.kt
@@ -12,12 +12,14 @@ import org.gabbard.pandemicgenerator.CityState
 import org.gabbard.pandemicgenerator.Color
 import org.gabbard.pandemicgenerator.Deck
 import org.gabbard.pandemicgenerator.EventCard
+import org.gabbard.pandemicgenerator.GameEvent
 import org.gabbard.pandemicgenerator.InfectionCard
 import org.gabbard.pandemicgenerator.InfectionRate
 import org.gabbard.pandemicgenerator.NamedEpidemic
 import org.gabbard.pandemicgenerator.Player
 import org.gabbard.pandemicgenerator.PlayerCard
 import org.gabbard.pandemicgenerator.Role
+import org.gabbard.pandemicgenerator.SimpleEpidemic
 import org.gabbard.pandemicgenerator.TrackableState
 import org.gabbard.pandemicgenerator.Transition
 import org.gabbard.pandemicgenerator.UntrackableState
@@ -51,12 +53,13 @@ class NavigationTest {
     }
 
     private fun drawPlayerCardsIntent(
-        playerCards: List<PlayerCard> = cities.take(5).map { CityPlayerCard(it) }
+        playerCards: List<PlayerCard> = cities.take(5).map { CityPlayerCard(it) },
+        eventLog: List<GameEvent> = emptyList()
     ): Intent = Intent(
         ApplicationProvider.getApplicationContext(),
         DrawPlayerCards::class.java
     ).apply {
-        putExtra(DrawPlayerCards.GAME_STATE, makeTrackableState(playerCards = playerCards))
+        putExtra(DrawPlayerCards.GAME_STATE, makeTrackableState(playerCards = playerCards, eventLog = eventLog))
         putExtra(DrawPlayerCards.RANDOM_SOURCE, Random(42))
         putExtra(DrawPlayerCards.SEED, 42L)
         putExtra(DrawPlayerCards.TURN_DURATION, TurnTimer.NO_TIMER)
@@ -353,6 +356,75 @@ class NavigationTest {
     }
 
     @Test
+    fun drawPlayerCardsWithFirstNamedEpidemicShowsVirulentStrainExplanation() {
+        val playerCards = listOf(
+            NamedEpidemic("Virulent Strain"),
+            CityPlayerCard(cities[0]),
+            CityPlayerCard(cities[1])
+        )
+        ActivityScenario.launch<DrawPlayerCards>(drawPlayerCardsIntent(playerCards = playerCards)).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = activity.findViewById<android.widget.LinearLayout>(R.id.cardsContainer)
+                val texts = (0 until container.childCount)
+                    .mapNotNull { container.getChildAt(it) as? android.widget.TextView }
+                    .map { it.text.toString() }
+                assertTrue(
+                    "Virulent Strain explanation should appear",
+                    texts.any { it.contains("Virulent Strain determination") }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun drawPlayerCardsWithSimpleEpidemicDoesNotShowVirulentStrainExplanation() {
+        val playerCards = listOf(
+            SimpleEpidemic(),
+            CityPlayerCard(cities[0]),
+            CityPlayerCard(cities[1])
+        )
+        ActivityScenario.launch<DrawPlayerCards>(drawPlayerCardsIntent(playerCards = playerCards)).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = activity.findViewById<android.widget.LinearLayout>(R.id.cardsContainer)
+                val texts = (0 until container.childCount)
+                    .mapNotNull { container.getChildAt(it) as? android.widget.TextView }
+                    .map { it.text.toString() }
+                assertTrue(
+                    "Virulent Strain explanation should not appear for a Simple epidemic",
+                    texts.none { it.contains("Virulent Strain determination") }
+                )
+            }
+        }
+    }
+
+    @Test
+    fun drawPlayerCardsDoesNotRepeatVirulentStrainExplanationAfterFirstOccurrence() {
+        val priorEvent = GameEvent.DrawPlayerCardsEvent(
+            cardsDrawn = listOf(NamedEpidemic("Earlier Virulent Strain")),
+            epidemicsAndInfectedCities = listOf(NamedEpidemic("Earlier Virulent Strain") to cities[5]),
+            player = Player(Role("Scientist"))
+        )
+        val playerCards = listOf(
+            NamedEpidemic("Virulent Strain"),
+            CityPlayerCard(cities[0]),
+            CityPlayerCard(cities[1])
+        )
+        val intent = drawPlayerCardsIntent(playerCards = playerCards, eventLog = listOf(priorEvent))
+        ActivityScenario.launch<DrawPlayerCards>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = activity.findViewById<android.widget.LinearLayout>(R.id.cardsContainer)
+                val texts = (0 until container.childCount)
+                    .mapNotNull { container.getChildAt(it) as? android.widget.TextView }
+                    .map { it.text.toString() }
+                assertTrue(
+                    "Virulent Strain explanation should not repeat once already determined",
+                    texts.none { it.contains("Virulent Strain determination") }
+                )
+            }
+        }
+    }
+
+    @Test
     fun drawPlayerCardsWithEventCardIsDisplayed() {
         val playerCards = listOf(
             EventCard("Airlift"),
@@ -498,7 +570,8 @@ class NavigationTest {
     private fun makeTrackableState(
         playerCards: List<PlayerCard> = cities.take(5).map { CityPlayerCard(it) },
         lastTransition: Transition = Transition.INFECT,
-        roleName: String = "Medic"
+        roleName: String = "Medic",
+        eventLog: List<GameEvent> = emptyList()
     ): TrackableState {
         val players = listOf(Player(Role(roleName)), Player(Role("Scientist")))
         return TrackableState(
@@ -508,7 +581,8 @@ class NavigationTest {
             infectionDiscardPile = cities.drop(10).map { InfectionCard(it) }.toSet(),
             playerDeck = Deck(playerCards),
             infectionRate = InfectionRate.INITIAL,
-            lastTransition = lastTransition
+            lastTransition = lastTransition,
+            eventLog = eventLog
         )
     }
 }

--- a/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/RuleSetTest.kt
+++ b/pandemic-generator-core/src/test/java/org/gabbard/pandemicgenerator/RuleSetTest.kt
@@ -140,11 +140,21 @@ class RuleSetTest {
         assertEquals(6, NATIONAL_CHAMPIONSHIP.availableEpidemics.size)
     }
 
+    @Test
+    fun nationalChampionshipUsesVirulentStrainEpidemics() {
+        assertTrue(NATIONAL_CHAMPIONSHIP.availableEpidemics.all { it is NamedEpidemic })
+    }
+
     // ── STANDARD_PANDEMIC configuration ──────────────────────────────────────
 
     @Test
     fun standardPandemicHasNoTimer() {
         assertNull(STANDARD_PANDEMIC.turnDurationSeconds)
+    }
+
+    @Test
+    fun standardPandemicDoesNotUseVirulentStrainEpidemics() {
+        assertTrue(STANDARD_PANDEMIC.availableEpidemics.all { it is SimpleEpidemic })
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Whether a rule set uses Virulent Strain epidemics was already fully configurable (`STANDARD_PANDEMIC`/`GENCON_2026` use plain `SimpleEpidemic`, `NATIONAL_CHAMPIONSHIP` uses `NamedEpidemic`, and new custom rule sets default to Simple/off via the existing "Simple (Standard Pandemic)" / "Named (Virulent Strain)" radio in `EditRuleSetActivity`) — that part just lacked explicit regression tests, which are added here.
- **`GameLogActivity`**: the "Virulent Strain determination" explanation was shown after the *first epidemic drawn in the game*, regardless of its type — so it incorrectly appeared even in Standard Pandemic / GenCon 2026 games, which use `SimpleEpidemic` cards and have no virulent strain mechanic. Now it only triggers on the first epidemic that is actually a `NamedEpidemic`.
- **`DrawPlayerCards`**: the explanation never appeared on the live "Draw Cards" screen at all — only retroactively in the Game Log. It now appears there too, the first time a virulent-strain epidemic is drawn, tracking prior turns' event log so it doesn't repeat.

Closes #76

## Test plan

- [x] Added `pandemic-generator-core` tests locking down that `NATIONAL_CHAMPIONSHIP` uses `NamedEpidemic` (virulent strain on) and `STANDARD_PANDEMIC` uses `SimpleEpidemic` (off). `./gradlew :pandemic-generator-core:test` passes.
- [x] Added Robolectric tests in `GameLogActivityTest` (explanation shown only for `NamedEpidemic`, not repeated across multiple virulent-strain epidemics) and `NavigationTest` (explanation shown live on the Draw Cards screen for a `NamedEpidemic`, not shown for a `SimpleEpidemic`, not repeated if already determined in a prior turn's event log).
- [ ] `app` module unit tests (including the new cases) were **not** run — this environment has no Android SDK configured (`ANDROID_HOME`/`local.properties` `sdk.dir` unset). Please run `./gradlew :app:testDebugUnitTest` before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCrwhkii4jSRtof59bxvQR)_